### PR TITLE
devnull all the things, we do our own messages

### DIFF
--- a/global.sh
+++ b/global.sh
@@ -26,15 +26,15 @@ parse_yaml() {
 gitupdate() {
 git remote add upstream https://github.com/jailmanager/jailman.git > /dev/null 2>&1
 echo "checking for updates using Branch: $1"
-git fetch upstream
-git update-index -q --refresh
-CHANGED=$(git diff --name-only "$1")
+git fetch upstream > /dev/null 2>&1
+git update-index -q --refresh > /dev/null 2>&1
+CHANGED=$(git diff --name-only "$1") > /dev/null 2>&1
 if [ -n "$CHANGED" ];
 then
     echo "script requires update"
-    git reset --hard
-    git checkout "${1}"
-    git pull
+    git reset --hard > /dev/null 2>&1
+    git checkout "${1}" > /dev/null 2>&1
+    git pull > /dev/null 2>&1
     echo "script updated, please restart the script manually"
     exit 1
 else

--- a/global.sh
+++ b/global.sh
@@ -28,7 +28,7 @@ git remote add upstream https://github.com/jailmanager/jailman.git > /dev/null 2
 echo "checking for updates using Branch: $1"
 git fetch upstream > /dev/null 2>&1
 git update-index -q --refresh > /dev/null 2>&1
-CHANGED=$(git diff --name-only "$1") > /dev/null 2>&1
+CHANGED=$(git diff --name-only "$1")
 if [ -n "$CHANGED" ];
 then
     echo "script requires update"


### PR DESCRIPTION
# Pull Request Template
### Purpose
This /dev/nulls the git output from the auto updater.
This became annoying as we do our own verbosity (and some error messages aren't relevant for our usecase)

### Notes:


### Please make sure you have followed the self checks below before submitting a PR:

- [X] Code is sufficiently commented
- [X] Code is indented with tabs and not spaces
- [X] The PR does not bring up any new errors
- [X] The PR has been tested
- [X] Any new files are named using lowercase (to avoid issues on case sensitive file systems)
