### PR TITLE
Don't try to update unifi poller if it isn't installed

### DIFF
--- a/blueprints/unifi/update.sh
+++ b/blueprints/unifi/update.sh
@@ -2,20 +2,25 @@
 # This file contains the update script for unifi
 # Unifi Controller is updated through pkg, Unifi-Poller is not. This script updates Unifi-Poller
 
-FILE_NAME=$(curl -s https://api.github.com/repos/unifi-poller/unifi-poller/releases/latest | jq -r ".assets[] | select(.name | contains(\"amd64.txz\")) | .name")
-DOWNLOAD=$(curl -s https://api.github.com/repos/unifi-poller/unifi-poller/releases/latest | jq -r ".assets[] | select(.name | contains(\"amd64.txz\")) | .browser_download_url")
-
-# Check to see if there is an update.
-# shellcheck disable=SC2154
-if [[ -f /mnt/"${global_dataset_config}"/"${1}"/"${FILE_NAME}" ]]; then
-  echo "Unifi-Poller is up to date."
-  exit 1
+if [[ ! "${!POLLER}" ]]; then
+	echo "Skipping Unifi Poller for update, not installed"
 else
-  # Download and install the package
-  iocage exec "${1}" fetch -o /config "${DOWNLOAD}"
-  iocage exec "${1}" pkg install -qy /config/"${FILE_NAME}"
-  iocage exec "${1}" service unifi restart
-  iocage exec "${1}" service unifi_poller restart
+	
+	FILE_NAME=$(curl -s https://api.github.com/repos/unifi-poller/unifi-poller/releases/latest | jq -r ".assets[] | select(.name | contains(\"amd64.txz\")) | .name")
+	DOWNLOAD=$(curl -s https://api.github.com/repos/unifi-poller/unifi-poller/releases/latest | jq -r ".assets[] | select(.name | contains(\"amd64.txz\")) | .browser_download_url")
+	
+	# Check to see if there is an update.
+	# shellcheck disable=SC2154
+	if [[ -f /mnt/"${global_dataset_config}"/"${1}"/"${FILE_NAME}" ]]; then
+		echo "Unifi-Poller is up to date."
+		exit 1
+	else
+		# Download and install the package
+		iocage exec "${1}" fetch -o /config "${DOWNLOAD}"
+		iocage exec "${1}" pkg install -qy /config/"${FILE_NAME}"
+		
+		iocage exec "${1}" service unifi_poller restart
+	fi
 fi
-
+iocage exec "${1}" service unifi restart
 echo "Update complete!"


### PR DESCRIPTION
# Pull Request Template
### Purpose
We shouldn't try to update unifipoller if it isn't installed.

### Notes:
Fixes #111

### Please make sure you have followed the self checks below before submitting a PR:

- [X] Code is sufficiently commented
- [X] Code is indented with tabs and not spaces
- [ ] The PR does not bring up any new errors
- [ ] The PR has been tested
- [X] Any new files are named using lowercase (to avoid issues on case sensitive file systems)
