### PR TITLE
Blueprint exit and includes refactor

### DIFF
--- a/blueprints/bitwarden/install.sh
+++ b/blueprints/bitwarden/install.sh
@@ -26,7 +26,6 @@ iocage exec "${1}" "git -C /usr/local/share/bitwarden/src checkout ${TAG}"
 
 iocage exec "${1}" "cd /usr/local/share/bitwarden/src && $HOME/.cargo/bin/cargo build --features mysql --release"
 iocage exec "${1}" "cd /usr/local/share/bitwarden/src && $HOME/.cargo/bin/cargo install diesel_cli --no-default-features --features mysql"
-
 iocage exec "${1}" cp -r /usr/local/share/bitwarden/src/target/release /usr/local/share/bitwarden/bin
 
 # Download and install webvault
@@ -59,8 +58,8 @@ fi
 iocage exec "${1}" "pw user add bitwarden -c bitwarden -u 725 -d /nonexistent -s /usr/bin/nologin"
 iocage exec "${1}" chown -R bitwarden:bitwarden /usr/local/share/bitwarden /config
 iocage exec "${1}" mkdir /usr/local/etc/rc.d /usr/local/etc/rc.conf.d
-cp "${SCRIPT_DIR}"/blueprints/bitwarden/includes/bitwarden.rc /mnt/"${global_dataset_iocage}"/jails/"${1}"/root/usr/local/etc/rc.d/bitwarden
-cp "${SCRIPT_DIR}"/blueprints/bitwarden/includes/bitwarden.rc.conf /mnt/"${global_dataset_iocage}"/jails/"${1}"/root/usr/local/etc/rc.conf.d/bitwarden
+cp -rf "${includes_dir}/bitwarden.rc" /mnt/"${global_dataset_iocage}"/jails/"${1}"/root/usr/local/etc/rc.d/bitwarden
+cp -rf "${includes_dir}/bitwarden.rc.conf" /mnt/"${global_dataset_iocage}"/jails/"${1}"/root/usr/local/etc/rc.conf.d/bitwarden
 echo 'export DATABASE_URL="'"${DB_STRING}"'"' >> /mnt/"${global_dataset_iocage}"/jails/"${1}"/root/usr/local/etc/rc.conf.d/bitwarden
 echo 'export ADMIN_TOKEN="'"${admin_token}"'"' >> /mnt/"${global_dataset_iocage}"/jails/"${1}"/root/usr/local/etc/rc.conf.d/bitwarden
 
@@ -74,5 +73,7 @@ fi
 iocage exec "${1}" chmod u+x /usr/local/etc/rc.d/bitwarden
 iocage exec "${1}" sysrc "bitwarden_enable=YES"
 iocage exec "${1}" service bitwarden restart
-echo "Jail ${1} finished Bitwarden install."
+
+
+exitblueprint "$1" "Bitwarden is now accessible at https://${ip4_addr%/*}:8000"
 echo "Admin Token is ${admin_token}"

--- a/blueprints/example/install.sh
+++ b/blueprints/example/install.sh
@@ -3,6 +3,13 @@
 
 initblueprint "$1"
 
+# Initialise defaults
+# You can add default values for the variables already loaded here.
+
 # Example jail content
 echo "Testvar = ${testvar}"
 echo "required testvar2 = ${testvar2}"
+
+
+exitblueprint "$1" "Exampleblueprint installation finished."
+# you can add additional echo output (but only echo output) after the exitblueprint

--- a/blueprints/influxdb/install.sh
+++ b/blueprints/influxdb/install.sh
@@ -17,7 +17,5 @@ iocage exec "${1}" sysrc influxd_enable="YES"
 iocage exec "${1}" service influxd start
 sleep 15
 
-# Done!
-echo "Installation complete!"
-echo "You may connect InfluxDB plugins to the InfluxDB jail at http://${ip4_addr%/*}:8086."
-echo ""
+exitblueprint "$1" "You may connect InfluxDB plugins to the InfluxDB jail at http://${ip4_addr%/*}:8086."
+

--- a/blueprints/jackett/install.sh
+++ b/blueprints/jackett/install.sh
@@ -12,7 +12,9 @@ iocage exec "$1" rm /usr/local/share/Jackett.Binaries.Mono.tar.gz
 iocage exec "$1" "pw user add jackett -c jackett -u 818 -d /nonexistent -s /usr/bin/nologin"
 iocage exec "$1" chown -R jackett:jackett /usr/local/share/Jackett /config
 iocage exec "$1" mkdir /usr/local/etc/rc.d
-cp "${SCRIPT_DIR}"/blueprints/jackett/includes/jackett.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/jackett
+cp "${includes_dir}"/jackett.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/jackett
 iocage exec "$1" chmod u+x /usr/local/etc/rc.d/jackett
 iocage exec "$1" sysrc "jackett_enable=YES"
 iocage exec "$1" service jackett restart
+
+exitblueprint "$1" "Jackett is now accessible at http://${ip4_addr%/*}:9117"

--- a/blueprints/kms/install.sh
+++ b/blueprints/kms/install.sh
@@ -10,7 +10,9 @@ iocage exec "$1" svn checkout https://github.com/SystemRage/py-kms/trunk/py-kms 
 iocage exec "$1" "pw user add kms -c kms -u 666 -d /nonexistent -s /usr/bin/nologin"
 iocage exec "$1" chown -R kms:kms /usr/local/share/py-kms /config
 iocage exec "$1" mkdir /usr/local/etc/rc.d
-cp "${SCRIPT_DIR}"/blueprints/kms/includes/py_kms.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/py_kms
+cp "${includes_dir}"/py_kms.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/py_kms
 iocage exec "$1" chmod u+x /usr/local/etc/rc.d/py_kms
 iocage exec "$1" sysrc "py_kms_enable=YES"
 iocage exec "$1" service py_kms start
+
+exitblueprint "$1" "KMS is now accessible at ${ip4_addr%/*}:1688"

--- a/blueprints/lidarr/install.sh
+++ b/blueprints/lidarr/install.sh
@@ -16,12 +16,14 @@ createmount "$1" "${global_dataset_media}"/music /mnt/music
 
 
 iocage exec "$1" "fetch https://github.com/lidarr/Lidarr/releases/download/v0.7.1.1381/Lidarr.master.0.7.1.1381.linux.tar.gz -o /usr/local/share"
-iocage exec "$1" "tar -xzvf Lidarr.master.0.7.1.1381.linux.tar.gz -C /usr/local/share"
+iocage exec "$1" "tar -xzvf /usr/local/share/Lidarr.master.0.7.1.1381.linux.tar.gz -C /usr/local/share"
 iocage exec "$1" "rm /usr/local/share/Lidarr.master.0.7.1.1381.linux.tar.gz"
 iocage exec "$1" "pw user add lidarr -c lidarr -u 353 -d /nonexistent -s /usr/bin/nologin"
 iocage exec "$1" chown -R lidarr:lidarr /usr/local/share/Lidarr /config
 iocage exec "$1" mkdir /usr/local/etc/rc.d
-cp "${SCRIPT_DIR}"/blueprints/lidarr/includes/lidarr.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/lidarr
+cp "${includes_dir}"/lidarr.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/lidarr
 iocage exec "$1" chmod u+x /usr/local/etc/rc.d/lidarr
 iocage exec "$1" sysrc "lidarr_enable=YES"
 iocage exec "$1" service lidarr start
+
+exitblueprint "$1" "Lidarr is now accessible at http://${ip4_addr%/*}:8686"

--- a/blueprints/mariadb/install.sh
+++ b/blueprints/mariadb/install.sh
@@ -25,10 +25,6 @@ zfs set primarycache=metadata "${global_dataset_config}"/"${1}"/db
 
 iocage exec "${1}" chown -R 88:88 /var/db/mysql
 
-# Install includes fstab
-iocage exec "${1}" mkdir -p /mnt/includes
-iocage fstab -a "${1}" "${includes_dir}" /mnt/includes nullfs rw 0 0
-
 iocage exec "${1}" mkdir -p /usr/local/www/phpmyadmin
 iocage exec "${1}" chown -R www:www /usr/local/www/phpmyadmin
 
@@ -49,8 +45,8 @@ iocage exec "${1}" sysrc mysql_enable="YES"
 
 # Copy and edit pre-written config files
 echo "Copying Caddyfile for no SSL"
-iocage exec "${1}" cp -f /mnt/includes/caddy.rc /usr/local/etc/rc.d/caddy
-iocage exec "${1}" cp -f /mnt/includes/Caddyfile /usr/local/www/Caddyfile
+cp "${includes_dir}"/caddy.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/caddy
+cp "${includes_dir}"/Caddyfile /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/www/Caddyfile
 iocage exec "${1}" sed -i '' "s/yourhostnamehere/${host_name}/" /usr/local/www/Caddyfile
 iocage exec "${1}" sed -i '' "s/JAIL-IP/${ip4_addr%/*}/" /usr/local/www/Caddyfile
 
@@ -67,7 +63,7 @@ if [ "${REINSTALL}" == "true" ]; then
 else
 	
 	# Secure database, set root password, create Nextcloud DB, user, and password
-	iocage exec "${1}" cp -f /mnt/includes/my-system.cnf /var/db/mysql/my.cnf
+	cp "${includes_dir}"/my-system.cnf /mnt/"${global_dataset_iocage}"/jails/"$1"/root/var/db/mysql/my.cnf
 	iocage exec "${1}" mysql -u root -e "DELETE FROM mysql.user WHERE User='';"
 	iocage exec "${1}" mysql -u root -e "DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');"
 	iocage exec "${1}" mysql -u root -e "DROP DATABASE IF EXISTS test;"
@@ -75,20 +71,14 @@ else
 	iocage exec "${1}" mysqladmin --user=root password "${root_password}"
 	iocage exec "${1}" mysqladmin reload
 	fi
-iocage exec "${1}" cp -f /mnt/includes/my.cnf /root/.my.cnf
+cp "${includes_dir}"/my.cnf /mnt/"${global_dataset_iocage}"/jails/"$1"/root/root/.my.cnf
 iocage exec "${1}" sed -i '' "s|mypassword|${root_password}|" /root/.my.cnf
 
 # Save passwords for later reference
 iocage exec "${1}" echo "MariaDB root password is ${root_password}" > /root/"${1}"_root_password.txt
-	
 
-# Don't need /mnt/includes any more, so unmount it
-iocage fstab -r "${1}" "${includes_dir}" /mnt/includes nullfs rw 0 0
-
-# Done!
-echo "Installation complete!"
-echo "Using your web browser, go to http://${host_name} to log in"
-
+exitblueprint "$1" "MariaDB is now accessible at http://${ip4_addr%/*}"
+echo "All passwords are saved in /root/${1}_db_password.txt"
 if [ "${REINSTALL}" == "true" ]; then
 	echo "You did a reinstall, please use your old database and account credentials"
 else
@@ -97,4 +87,3 @@ else
 	echo "The MariaDB root password is ${root_password}"
 	fi
 echo ""
-echo "All passwords are saved in /root/${1}_db_password.txt"

--- a/blueprints/nextcloud/install.sh
+++ b/blueprints/nextcloud/install.sh
@@ -59,11 +59,6 @@ createmount "${1}" "${global_dataset_config}"/"${1}"/config /usr/local/www/nextc
 createmount "${1}" "${global_dataset_config}"/"${1}"/themes /usr/local/www/nextcloud/themes
 createmount "${1}" "${global_dataset_config}"/"${1}"/files /config/files
 
-# Install includes fstab
-iocage exec "${1}" mkdir -p /mnt/includes
-iocage fstab -a "${1}" "${includes_dir}" /mnt/includes nullfs rw 0 0
-
-
 iocage exec "${1}" chown -R www:www /config/files
 iocage exec "${1}" chmod -R 770 /config/files
 
@@ -116,34 +111,31 @@ if [ "$cert_type" == "SELFSIGNED_CERT" ] && [ ! -f "/mnt/${global_dataset_config
 		iocage exec "${1}" mkdir /config/ssl
 	fi
 		openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=${host_name}" -keyout "${includes_dir}"/privkey.pem -out "${includes_dir}"/fullchain.pem
-	iocage exec "${1}" cp /mnt/includes/privkey.pem /config/ssl/privkey.pem
-	iocage exec "${1}" cp /mnt/includes/fullchain.pem /config/ssl/fullchain.pem
+	cp "${includes_dir}"/privkey.pem /mnt/"${global_dataset_iocage}"/jails/"$1"/root/config/ssl/privkey.pem
+	cp "${includes_dir}"/fullchain.pem /mnt/"${global_dataset_iocage}"/jails/"$1"/root/config/ssl/fullchain.pem
 fi
 
 # Copy and edit pre-written config files
-iocage exec "${1}" cp -f /mnt/includes/php.ini /usr/local/etc/php.ini
-iocage exec "${1}" cp -f /mnt/includes/redis.conf /usr/local/etc/redis.conf
-iocage exec "${1}" cp -f /mnt/includes/www.conf /usr/local/etc/php-fpm.d/
-
+cp "${includes_dir}"/php.ini /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/php.ini
+cp "${includes_dir}"/redis.conf /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/redis.conf
+cp "${includes_dir}"/www.conf /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/php-fpm.d/
 
 if [ "$cert_type" == "STANDALONE_CERT" ] && [ "$cert_type" == "DNS_CERT" ]; then
-	iocage exec "${1}" cp -f /mnt/includes/remove-staging.sh /root/
+	cp "${includes_dir}"/remove-staging.sh /mnt/"${global_dataset_iocage}"/jails/"$1"/root/root/
 fi
 
 if [ "$cert_type" == "NO_CERT" ]; then
 	echo "Copying Caddyfile for no SSL"
-	iocage exec "${1}" cp -f /mnt/includes/Caddyfile-nossl /usr/local/www/Caddyfile
+	cp "${includes_dir}"/Caddyfile-nossl /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/www/Caddyfile
 elif [ "$cert_type" == "SELFSIGNED_CERT" ]; then
 	echo "Copying Caddyfile for self-signed cert"
-	iocage exec "${1}" cp -f /mnt/includes/Caddyfile-selfsigned /usr/local/www/Caddyfile
+	cp "${includes_dir}"/Caddyfile-selfsigned /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/www/Caddyfile
 else
 	echo "Copying Caddyfile for Let's Encrypt cert"
-	iocage exec "${1}" cp -f /mnt/includes/Caddyfile /usr/local/www/
+	cp "${includes_dir}"/Caddyfile /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/www/
 fi
 
-
-iocage exec "${1}" cp -f /mnt/includes/caddy.rc /usr/local/etc/rc.d/caddy
-
+cp "${includes_dir}"/caddy.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/caddy
 
 iocage exec "${1}" sed -i '' "s/yourhostnamehere/${host_name}/" /usr/local/www/Caddyfile
 iocage exec "${1}" sed -i '' "s/DNS-PLACEHOLDER/${DNS_SETTING}/" /usr/local/www/Caddyfile
@@ -208,15 +200,12 @@ iocage exec "${1}" chown www /var/log/nextcloud.log
 iocage exec "${1}" su -m www -c 'php -f /usr/local/www/nextcloud/cron.php'
 iocage exec "${1}" crontab -u www /mnt/includes/www-crontab
 
-# Don't need /mnt/includes any more, so unmount it
-iocage fstab -r "${1}" "${includes_dir}" /mnt/includes nullfs rw 0 0
+exitblueprint "$1" "Nextcloud is accessible at ${urltype}://${host_name}"
 
-# Done!
-echo "Installation complete!"
 if [ "$cert_type" == "NO_CERT" ]; then
-  echo "Using your web browser, go to http://${host_name} to log in"
+  urltype="http"
 else
-  echo "Using your web browser, go to https://${host_name} to log in"
+  urltype="https"
 fi
 
 if [ "${REINSTALL}" == "true" ]; then
@@ -252,4 +241,3 @@ elif [ "$cert_type" == "SELFSIGNED_CERT" ]; then
   echo "/config/ssl/fullchain.pem"
   echo ""
 fi
-

--- a/blueprints/organizr/install.sh
+++ b/blueprints/organizr/install.sh
@@ -14,8 +14,8 @@ iocage exec "$1" cp /usr/local/etc/php.ini-production /usr/local/etc/php.ini
 iocage exec "$1" sed -i '' -e 's?;date.timezone =?date.timezone = "Universal"?g' /usr/local/etc/php.ini
 iocage exec "$1" sed -i '' -e 's?;cgi.fix_pathinfo=1?cgi.fix_pathinfo=0?g' /usr/local/etc/php.ini
 mv /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/nginx/nginx.conf /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/nginx/nginx.conf.bak
-cp "${SCRIPT_DIR}"/blueprints/organizr/includes/nginx.conf /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/nginx/nginx.conf
-cp -Rf "${SCRIPT_DIR}"/blueprints/organizr/includes/custom /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/nginx/custom
+cp "${includes_dir}"/nginx.conf /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/nginx/nginx.conf
+cp -Rf "${includes_dir}"/custom /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/nginx/custom
 if [ ! -d "/mnt/${global_dataset_config}/$1/ssl" ]; then
 	echo "cert folder doesn't exist... creating..."
 	iocage exec "$1" mkdir /config/ssl
@@ -35,3 +35,6 @@ iocage exec "$1" sysrc nginx_enable=YES
 iocage exec "$1" sysrc php_fpm_enable=YES
 iocage exec "$1" service nginx start
 iocage exec "$1" service php-fpm start
+
+exitblueprint "$1" "Organizr is now accessible at http://${ip4_addr%/*}"
+

--- a/blueprints/plex/install.sh
+++ b/blueprints/plex/install.sh
@@ -9,7 +9,7 @@ initblueprint "$1"
 iocage exec plex mkdir -p /usr/local/etc/pkg/repos
 
 # Change to to more frequent FreeBSD repo to stay up-to-date with plex more.
-cp "${SCRIPT_DIR}"/blueprints/plex/includes/FreeBSD.conf /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/pkg/repos/FreeBSD.conf
+cp "${includes_dir}"/FreeBSD.conf /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/pkg/repos/FreeBSD.conf
 
 
 # Check if datasets for media librarys exist, create them if they do not.
@@ -49,4 +49,4 @@ else
 	iocage exec "$1" service plexmediaserver restart
 fi
 
-echo "Finished installing plex"
+exitblueprint "$1" "Plex is now accessible at https://${ip4_addr%/*}:32400/web/"

--- a/blueprints/radarr/install.sh
+++ b/blueprints/radarr/install.sh
@@ -20,7 +20,9 @@ iocage exec "$1" rm /usr/local/share/Radarr.develop.0.2.0.1480.linux.tar.gz
 iocage exec "$1" "pw user add radarr -c radarr -u 352 -d /nonexistent -s /usr/bin/nologin"
 iocage exec "$1" chown -R radarr:radarr /usr/local/share/Radarr /config
 iocage exec "$1" mkdir /usr/local/etc/rc.d
-cp "${SCRIPT_DIR}"/blueprints/radarr/includes/radarr.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/radarr
+cp "${includes_dir}"/radarr.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/radarr
 iocage exec "$1" chmod u+x /usr/local/etc/rc.d/radarr
 iocage exec "$1" sysrc "radarr_enable=YES"
 iocage exec "$1" service radarr restart
+
+exitblueprint "$1" "Radarr is now accessible at http://${ip4_addr%/*}:7878"

--- a/blueprints/sonarr/install.sh
+++ b/blueprints/sonarr/install.sh
@@ -20,7 +20,9 @@ iocage exec "$1" rm /usr/local/share/NzbDrone.master.tar.gz
 iocage exec "$1" "pw user add sonarr -c sonarr -u 351 -d /nonexistent -s /usr/bin/nologin"
 iocage exec "$1" chown -R sonarr:sonarr /usr/local/share/NzbDrone /config
 iocage exec "$1" mkdir /usr/local/etc/rc.d
-cp "${SCRIPT_DIR}"/blueprints/sonarr/includes/sonarr.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/sonarr
+cp "${includes_dir}"/sonarr.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/sonarr
 iocage exec "$1" chmod u+x /usr/local/etc/rc.d/sonarr
 iocage exec "$1" sysrc "sonarr_enable=YES"
 iocage exec "$1" service sonarr restart
+
+exitblueprint "$1" "Sonarr is now accessible at http://${ip4_addr%/*}:8989"

--- a/blueprints/tautulli/install.sh
+++ b/blueprints/tautulli/install.sh
@@ -14,3 +14,5 @@ iocage exec "$1" chmod u+x /usr/local/etc/rc.d/tautulli
 iocage exec "$1" sysrc "tautulli_enable=YES"
 iocage exec "$1" sysrc "tautulli_flags=--datadir /config"
 iocage exec "$1" service tautulli start
+
+exitblueprint "$1" "Tautulli is now accessible at http://${ip4_addr%/*}:8181"

--- a/blueprints/transmission/install.sh
+++ b/blueprints/transmission/install.sh
@@ -21,3 +21,5 @@ iocage exec "$1" sysrc "transmission_enable=YES"
 iocage exec "$1" sysrc "transmission_conf_dir=/config"
 iocage exec "$1" sysrc "transmission_download_dir=/mnt/downloads/complete"
 iocage exec "$1" service transmission restart
+
+exitblueprint "$1" "Transmission is now accessible at http://${ip4_addr%/*}:9091"

--- a/blueprints/unifi/install.sh
+++ b/blueprints/unifi/install.sh
@@ -23,9 +23,8 @@ cp "${includes_dir}"/rc/unifi.rc /mnt/"${global_dataset_iocage}"/jails/"${1}"/ro
 iocage exec "${1}" sysrc unifi_enable=YES
 iocage exec "${1}" service unifi start
 
-if [[ ! "${unifi_poller}" ]]; then
-  echo "Installation complete!"
-  echo "Unifi Controller is accessible at https://${ip4_addr%/*}:8443."
+if [[ ! "${poller}" ]]; then
+  echo "Unifi Poller not selected, skipping Unifi Poller installation."
 else
 	if [ -z "${influxdb_password}" ]; then
 	echo "influxdb_password can't be empty"
@@ -42,6 +41,7 @@ else
 	exit 1
 	fi
   # Check if influxdb container exists, create unifi database if it does, error if it is not.
+  echo "Installing Unifi Poller..."
   echo "Checking if the database jail and database exist..."
   if [[ -d /mnt/"${global_dataset_iocage}"/jails/"${link_influxdb}" ]]; then
     DB_EXISTING=$(iocage exec "${link_influxdb}" curl -G http://"${DB_IP}":8086/query --data-urlencode 'q=SHOW DATABASES' | jq '.results [] | .series [] | .values []' | grep "$influxdb_database" | sed 's/"//g' | sed 's/^ *//g')
@@ -70,8 +70,8 @@ else
 
   # Install downloaded Unifi-Poller package, configure and enable 
   iocage exec "${1}" pkg install -qy /config/"${FILE_NAME}"
-    cp "${includes_dir}"/up.conf /mnt/"${global_dataset_config}"/"${1}"
-    cp "${includes_dir}"/rc/unifi_poller.rc /mnt/"${global_dataset_iocage}"/jails/"${1}"/root/usr/local/etc/rc.d/unifi_poller
+  cp "${includes_dir}"/up.conf /mnt/"${global_dataset_config}"/"${1}"
+  cp "${includes_dir}"/rc/unifi_poller.rc /mnt/"${global_dataset_iocage}"/jails/"${1}"/root/usr/local/etc/rc.d/unifi_poller
   chmod +x /mnt/"${global_dataset_iocage}"/jails/"${1}"/root/usr/local/etc/rc.d/unifi_poller
   iocage exec "${1}" sed -i '' "s|influxdbuser|${influxdb_user}|" /config/up.conf
   iocage exec "${1}" sed -i '' "s|influxdbpass|${influxdb_password}|" /config/up.conf
@@ -84,8 +84,9 @@ else
   iocage exec "${1}" sysrc unifi_poller_enable=YES
   iocage exec "${1}" service unifi_poller start
 
-  echo "Installation complete!"
-  echo "Unifi Controller is accessible at https://${ip4_addr%/*}:8443."
   echo "Please login to the Unifi Controller and add ${poller_user} as a read-only user."
   echo "In Grafana, add Unifi-Poller as a data source."
 fi
+
+exitblueprint "$1" "Unifi Controller is now accessible at https://${ip4_addr%/*}:8443"
+

--- a/blueprints/unifi/update.sh
+++ b/blueprints/unifi/update.sh
@@ -5,7 +5,7 @@
 #init jail
 initblueprint "$1"
 
-if [[ ! "${unifi_poller}" ]]; then
+if [[ ! "${poller}" ]]; then
 	echo "Skipping Unifi Poller for update, not installed"
 else
 	FILE_NAME=$(curl -s https://api.github.com/repos/unifi-poller/unifi-poller/releases/latest | jq -r ".assets[] | select(.name | contains(\"amd64.txz\")) | .name")

--- a/docs/development/functions.md
+++ b/docs/development/functions.md
@@ -1,0 +1,37 @@
+# Custom Functions
+
+## Intro
+
+With Jailman we have a number of functions that are custom. This document lists them and explains their use. Currently all custom functions are inculded in ./includes/global.sh
+
+## parse_yaml
+This functions parses the yml config files. It does not support lists however and we highly advice not using indentations other than 2 spaces either.
+It's only input is a yml file and it should be called as the argument of an eval statement.
+
+## gitupdate
+This function triggers an update based on the branch it is given.
+Currently only called in jailman.sh and it is fed the remote/branch combo it is currently on.
+
+## jailcreate
+This function creates the actual jail based on a blueprint.
+It takes the jail name, looks up the blueprint and proceeds accordingly.
+It also creates things like basic mount points and such. while also checking if all required vars are filled.
+
+Currently only used in jailman.sh
+
+## initblueprint
+This function turns all config.yml variables for the jail inputed as $1 into local variables. This is not required (as variables are also available as `${!jail_$1_varname}`), but makes it easier for less experienced blueprint creators to start working with Jailman
+It takes only the Jailname as input.
+
+## exitblueprint
+This script does the "success" processing for an installation. It takes the name of the jail and a message (preferable a connection instruction), creates the "INSTALLED" file, does the last checks and outputs the successmessages
+No additional scripting besides `echo`'s should be done after executing this script.
+
+## createmount
+This function creates a dataset and mounts said dataset to a specific folder in a jail, while also creating required subfolders if needed.
+It's easier to use and update than mounting folders manually, so it's the only allowed way to do so, unless very specific config is required (such as database datasets)
+It has the following input options:
+# $1 = jail name
+# $2 = Dataset
+# $3 = Target mountpoint
+# $4 = fstab prefernces

--- a/includes/global.sh
+++ b/includes/global.sh
@@ -126,7 +126,6 @@ echo "Jail creation completed for ${1}"
 }
 
 initblueprint() {
-
 blueprint=jail_${1}_blueprint
 varlist=blueprint_${!blueprint}_vars
 
@@ -134,11 +133,24 @@ for var in ${!varlist} ${global_jails_vars}
 do
 	value="jail_${1}_$var"
     declare -g "${var}=${!value}"
-	echo "Set variable $var to ${!var}"
 done
+
 declare -g "includes_dir=${SCRIPT_DIR}/blueprints/${!blueprint}/includes"
 }
 export -f initblueprint
+
+exitblueprint() {
+blueprint=jail_${1}_blueprint
+echo "DO NOT DELETE THIS FILE" >> "/mnt/${global_dataset_config}/${1}/INSTALLED"
+echo "Jail $1 using blueprint ${!blueprint}, installed successfully."
+if [[ ! "${2}" ]]; then
+ echo "Please consult the wiki for instructions connecting to your newly installed jail" 
+else
+ echo ${2}
+fi
+
+}
+export -f exitblueprint
 
 # $1 = jail name
 # $2 = Dataset


### PR DESCRIPTION
# Pull Request Template
### Purpose
This PR standardises and refactors the exit portion of the blueprint scripts. Things like: Success messages, connection references and setting the last flags.

This does look like it adds code instead of decreasing the code base. However, this is due to the fact that previously not all blueprints had appropiate success messages and didn't give connection instructions.

Also added is a hook to do future reinstall checks:
It creates a file called "INSTALLED" in the config dir, that we can check to get if a jail is successfully installed.

It also standardises the includes cp behavoir and adds documentation for all functions in global.sh

### Notes:
Fixes #109
and with this and the previous refactors it also Fixes #92

### Please make sure you have followed the self checks below before submitting a PR:

- [X] Code is sufficiently commented
- [X] Code is indented with tabs and not spaces
- [X] The PR does not bring up any new errors
- [X] The PR has been tested
- [X] Any new files are named using lowercase (to avoid issues on case sensitive file systems)
