### PR TITLE
Refactor: Reinstall, CreateMount, Initblueprint

### DIFF
--- a/blueprints/bitwarden/install.sh
+++ b/blueprints/bitwarden/install.sh
@@ -46,12 +46,12 @@ else
 	openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" -keyout /mnt/"${global_dataset_config}"/"${1}"/ssl/bitwarden-ssl.key -out /mnt/"${global_dataset_config}"/"${1}"/ssl/bitwarden-ssl.crt
 fi
 
-if [ -f "/mnt/${global_dataset_config}/${1}/bitwarden.log" ]; then
+if [ "${reinstall}" = "true" ]; then
 	echo "Reinstall of Bitwarden detected... using existing config and database"
 else
 	echo "No config detected, doing clean install, utilizing the Mariadb database ${DB_HOST}"
 	iocage exec "${link_mariadb}" mysql -u root -e "CREATE DATABASE ${mariadb_database};"
-		iocage exec "${link_mariadb}" mysql -u root -e "GRANT ALL ON ${mariadb_database}.* TO ${mariadb_user}@${ip4_addr%/*} IDENTIFIED BY '${mariadb_password}';"
+	iocage exec "${link_mariadb}" mysql -u root -e "GRANT ALL ON ${mariadb_database}.* TO ${mariadb_user}@${ip4_addr%/*} IDENTIFIED BY '${mariadb_password}';"
 	iocage exec "${link_mariadb}" mysqladmin reload
 fi
 

--- a/blueprints/example/config.yml
+++ b/blueprints/example/config.yml
@@ -1,5 +1,5 @@
 blueprint:
   example:
     pkgs: nano
-    vars: testvar testvar2 link_mariadb
+    vars: testvar testvar2 link_testjail
     reqvars: testvar

--- a/blueprints/example/config.yml
+++ b/blueprints/example/config.yml
@@ -1,5 +1,5 @@
 blueprint:
   example:
     pkgs: nano
-    vars: testvar testvar2
+    vars: testvar testvar2 link_mariadb
     reqvars: testvar

--- a/blueprints/example/install.sh
+++ b/blueprints/example/install.sh
@@ -10,6 +10,13 @@ initblueprint "$1"
 echo "Testvar = ${testvar}"
 echo "required testvar2 = ${testvar2}"
 
+echo "linked database ip: ${link_mariadb_ip4_addr}"
+
+if [ "${reinstall}" = "true" ]; then
+	echo "Reinstall detected..."
+else
+	echo "no reinstall detected, normal install proceeding..."
+fi
 
 exitblueprint "$1" "Exampleblueprint installation finished."
 # you can add additional echo output (but only echo output) after the exitblueprint

--- a/blueprints/example/install.sh
+++ b/blueprints/example/install.sh
@@ -10,7 +10,7 @@ initblueprint "$1"
 echo "Testvar = ${testvar}"
 echo "required testvar2 = ${testvar2}"
 
-echo "linked database ip: ${link_mariadb_ip4_addr}"
+echo "linked testjail ip: ${link_testjail_ip4_addr}"
 
 if [ "${reinstall}" = "true" ]; then
 	echo "Reinstall detected..."

--- a/blueprints/mariadb/install.sh
+++ b/blueprints/mariadb/install.sh
@@ -9,13 +9,6 @@ cert_email="${cert_email:-placeholder@email.fake}"
 DL_FLAGS=""
 DNS_ENV=""
 
-
-# Make sure DB_PATH is empty -- if not, MariaDB/PostgreSQL will choke
-if [ "$(ls -A "/mnt/${global_dataset_config}/${1}/db")" ]; then
-	echo "Reinstall of mariadb detected... Continuing"
-	REINSTALL="true"
-fi
-
 # Mount database dataset and set zfs preferences
 iocage exec "${1}" service mysql-server stop
 iocage exec "${1}" rm -Rf /var/db/mysql
@@ -58,7 +51,7 @@ iocage exec "${1}" sysrc caddy_env="${DNS_ENV}"
 iocage restart "${1}"
 sleep 10
 
-if [ "${REINSTALL}" == "true" ]; then
+if [ "${reinstall}" = "true" ]; then
 	echo "Reinstall detected, skipping generaion of new config and database"
 else
 	
@@ -79,7 +72,8 @@ iocage exec "${1}" echo "MariaDB root password is ${root_password}" > /root/"${1
 
 exitblueprint "$1" "MariaDB is now accessible at http://${ip4_addr%/*}"
 echo "All passwords are saved in /root/${1}_db_password.txt"
-if [ "${REINSTALL}" == "true" ]; then
+if [ "${reinstall}" = "true" ]; 
+then
 	echo "You did a reinstall, please use your old database and account credentials"
 else
 	echo "Database Information"

--- a/blueprints/nextcloud/install.sh
+++ b/blueprints/nextcloud/install.sh
@@ -41,13 +41,6 @@ if [ "$cert_type" == "DNS_CERT" ]; then
 	fi 
 fi  
 
-# Check for existing config
-if [ "$(ls -A "/mnt/${global_dataset_config}/${1}/config")" ]; then
-	echo "Reinstall of Nextcloud detected... "
-	REINSTALL="true"
-fi
-
-
 #####
 # 
 # Fstab And Mounts
@@ -149,7 +142,7 @@ iocage exec "${1}" sysrc caddy_env="${dns_env}"
 
 iocage restart "${1}"
 
-if [ "${REINSTALL}" == "true" ]; then
+if [ "${reinstall}" = "true" ]; then
 	echo "Reinstall detected, skipping generaion of new config and database"
 else
 	
@@ -208,7 +201,7 @@ else
   urltype="https"
 fi
 
-if [ "${REINSTALL}" == "true" ]; then
+if [ "${reinstall}" = "true" ]; then
 	echo "You did a reinstall, please use your old database and account credentials"
 else
 

--- a/docs/development/linked_configs.md
+++ b/docs/development/linked_configs.md
@@ -1,0 +1,19 @@
+# Linking Jail Configs
+
+## Intro
+To keep things simple, you can easily link jail configs together, for example you can make the settings of your MariaDB jail accessable to your nextcloud jail.
+This can be done using a variable with the name: `link_$Name`, where $Name is just a description and the value in config.yml would be the actual jail to connect to.
+
+For example:
+`link_testjail: thisismytestjail`
+
+Would link "thisismytestjail" to your current jail.
+
+## using linked jails
+
+Once setup one can reach all the variables of the linked jail using the following syntax:
+`link_$Name_$variable`
+
+For example if we want the ipv4 address of the jail we linked earlier, during the install of another jail, we would do:
+`link_testjail_ip4_addr`
+	


### PR DESCRIPTION
# Pull Request Template
### Purpose
This PR adds a standardised reinstall check to the initblueprint script.
It's goal is to make sure a blueprint installation has actually finished correctly and to prevent reinstalls triggering after botched installs. So it uses the previously added INSTALLED file added with the blueprint exit refactor.

It also changes Createmount and Initblueprint, to be compatible with stricter bash flags as required by #48 

As an extra it also automatically fetches all variables for linked jails.
From now on one can get the variable for a linked jail by just using link_$jailname_$variable (ex. link_mariadb_ip4_addr)

### Notes:
Blocked because it requires #142 to be merged first
Fixes #113 

### Please make sure you have followed the self checks below before submitting a PR:

- [X] Code is sufficiently commented
- [X] Code is indented with tabs and not spaces
- [x] The PR does not bring up any new errors
- [x] The PR has been tested
- [X] Any new files are named using lowercase (to avoid issues on case sensitive file systems)
