### PR TITLE
Add Traefik

### DIFF
--- a/blueprints/traefik/config.yml
+++ b/blueprints/traefik/config.yml
@@ -1,5 +1,5 @@
 blueprint:
   traefik:
     pkgs: traefik2
-    vars: domain_name cert_email cert_provider cert_wildcard_domain cert_staging
-    reqvars: cert_email cert_provider
+    vars: domain_name cert_email dns_provider cert_wildcard_domain cert_staging cert_strict_sni
+    reqvars: cert_email dns_provider

--- a/blueprints/traefik/config.yml
+++ b/blueprints/traefik/config.yml
@@ -1,5 +1,5 @@
 blueprint:
   traefik:
     pkgs: traefik2
-    vars: domain_name cert_email dns_provider cert_wildcard_domain cert_staging cert_strict_sni
+    vars: domain_name cert_email dns_provider cert_wildcard_domain cert_staging cert_strict_sni dashboard
     reqvars: cert_email dns_provider

--- a/blueprints/traefik/config.yml
+++ b/blueprints/traefik/config.yml
@@ -1,0 +1,5 @@
+blueprint:
+  traefik:
+    pkgs: traefik2
+    vars: domain_name cert_email cert_provider cert_wildcard_domain cert_staging
+    reqvars: cert_email cert_provider

--- a/blueprints/traefik/includes/dashboard.toml
+++ b/blueprints/traefik/includes/dashboard.toml
@@ -5,6 +5,11 @@
         scheme = "https"
 
     [http.routers]
+       [http.routers.http-catchall]
+          rule = "hostregexp(`{host:.+}`)"
+          service = "api@internal"
+          entryPoints = ["web"]
+		  middlewares = "redirect-to-https"
        [http.routers.traefik]
           rule = "Host(`placeholderdashboardhost`)"
           service = "api@internal"

--- a/blueprints/traefik/includes/dashboard.toml
+++ b/blueprints/traefik/includes/dashboard.toml
@@ -1,0 +1,17 @@
+[http]
+    # Redirect to https
+    [http.middlewares]
+      [http.middlewares.redirect-to-https.redirectScheme]
+        scheme = "https"
+
+    [http.routers]
+       [http.routers.traefik]
+          rule = "Host(`placeholderdashboardhost`)"
+          service = "api@internal"
+          entryPoints = ["web-secure"]
+        [http.routers.traefik.tls]
+          certResolver = "default" # From static configuration
+    [http.services]
+        [http.services.justAdummyService.loadbalancer]
+            [[http.services.justAdummyService.loadbalancer.servers]]
+                url = "http://localhost:1337"

--- a/blueprints/traefik/includes/dashboard_wildcard.toml
+++ b/blueprints/traefik/includes/dashboard_wildcard.toml
@@ -1,0 +1,20 @@
+[http]
+    # Redirect to https
+    [http.middlewares]
+      [http.middlewares.redirect-to-https.redirectScheme]
+        scheme = "https"
+
+    [http.routers]
+       [http.routers.traefik]
+          rule = "Host(`placeholderdashboardhost`)"
+          service = "api@internal"
+          entryPoints = ["web-secure"]
+        [http.routers.traefik.tls]
+          certResolver = "default" # From static configuration
+          [[http.routers.traefik.tls.domains]]
+            main = "placeholderwildcard"
+            sans = ["*.placeholderwildcard"]
+    [http.services]
+        [http.services.justAdummyService.loadbalancer]
+            [[http.services.justAdummyService.loadbalancer.servers]]
+                url = "http://localhost:1337"

--- a/blueprints/traefik/includes/firewall.rules
+++ b/blueprints/traefik/includes/firewall.rules
@@ -1,0 +1,4 @@
+ipfw -q -f flush
+cmd="ipfw -q add"
+$cmd 1000 fwd localhost,9080 tcp from any to me 80
+$cmd 1001 fwd localhost,9443 tcp from any to me 443

--- a/blueprints/traefik/includes/ssl.yml
+++ b/blueprints/traefik/includes/ssl.yml
@@ -1,0 +1,16 @@
+tls:
+  options:
+    default:
+      minVersion: VersionTLS12
+      cipherSuites:
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+        - TLS_AES_128_GCM_SHA256
+        - TLS_AES_256_GCM_SHA384
+        - TLS_CHACHA20_POLY1305_SHA256
+      curvePreferences:
+        - CurveP521
+        - CurveP384
+
+

--- a/blueprints/traefik/includes/traefik.toml
+++ b/blueprints/traefik/includes/traefik.toml
@@ -1,0 +1,32 @@
+[log]
+  level = "DEBUG"
+  filePath = "/config/traefik.log"
+
+[accessLog]
+  filePath =  "/config/traefik-access.log"
+  bufferingSize =  100
+
+[providers]
+  [providers.file]
+    directory = "/config/dynamic"
+
+[ping]
+
+[api]
+  dashboard = true
+  insecure = false
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":9080"
+  [entryPoints.web-secure]
+    address = ":9443"
+
+[certificatesResolvers.default.acme]
+  email = "placeholderemail"
+  caServer = "leserverplaceholder"
+  storage = "/config/acme.json"
+
+  [certificatesResolvers.default.acme.dnsChallenge]
+    provider = "placeholderprovider"
+    delayBeforeCheck = "5s"

--- a/blueprints/traefik/includes/traefik.toml
+++ b/blueprints/traefik/includes/traefik.toml
@@ -13,7 +13,7 @@
 [ping]
 
 [api]
-  dashboard = true
+  dashboard = dashplaceholder
   insecure = false
 
 [entryPoints]

--- a/blueprints/traefik/install.sh
+++ b/blueprints/traefik/install.sh
@@ -1,0 +1,72 @@
+#!/usr/local/bin/bash
+# This file contains the install script to install traefik as Jailman Reverse Proxy
+
+# init blueprint
+initblueprint "$1"
+
+# Set default variable values
+iptmp=${ip4_addr%/*}
+domain_name="${domain_name:-$iptmp}"
+productionurl="https://acme-v02.api.letsencrypt.org/directory"
+stagingurl="https://acme-staging-v02.api.letsencrypt.org/directory"
+
+# Copy the needed config files
+iocage exec "${1}" mkdir /config/dynamic/
+cp "${includes_dir}"/traefik.toml /mnt/"${global_dataset_config}"/"${1}"/
+cp "${includes_dir}"/firewall.rules /mnt/"${global_dataset_config}"/"${1}"/
+cp "${includes_dir}"/ssl.yml /mnt/"${global_dataset_config}"/"${1}"/dynamic/
+
+if [ -z "$cert_wildcard_domain" ];
+then
+	echo "wildcard not set, using non-wildcard config..."
+	cp "${includes_dir}"/dashboard.toml /mnt/"${global_dataset_config}"/"${1}"/dynamic/dashboard.toml
+else
+	echo "wildcard set, using wildcard config..."
+	cp "${includes_dir}"/dashboard_wildcard.toml /mnt/"${global_dataset_config}"/"${1}"/dynamic/dashboard.toml
+fi
+
+# Create DNS verification env-vars (as required by traefik)
+mkdir -p /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.conf.d
+dnsenv=$(printenv | grep "jail_${1}_cert_env_" | grep -o 'env_.*' | cut -f2- -d_ | tr "\n" " "; echo)
+iocage exec "$1" sysrc "traefik_env=${dnsenv}"
+
+# Replace placeholders with actual config
+iocage exec "${1}" sed -i '' "s|placeholderemail|${cert_email}|" /config/traefik.toml
+iocage exec "${1}" sed -i '' "s|placeholderprovider|${dns_provider}|" /config/traefik.toml
+iocage exec "${1}" sed -i '' "s|placeholderdashboardhost|${domain_name}|" /config/dynamic/dashboard.toml
+iocage exec "${1}" chown -R traefik:traefik /config
+
+if [ -z "$cert_wildcard_domain" ];
+then
+	echo "wildcard not set, not enabling wildcard config..."
+else
+	echo "wildcard set, enabling wildcard config..."
+	iocage exec "${1}" sed -i '' "s|placeholderwildcard|${cert_wildcard_domain}|" /config/dynamic/dashboard.toml
+fi
+
+if [ -z "$cert_staging" ] || [ "$cert_staging" = "false" ];
+then
+	echo "staging not set, using production server for LetsEncrypt"
+	iocage exec "${1}" sed -i '' "s|leserverplaceholder|${productionurl}|" /config/traefik.toml
+else
+	echo "staging set, using staging server for LetsEncrypt"
+	iocage exec "${1}" sed -i '' "s|leserverplaceholder|${stagingurl}|" /config/traefik.toml
+fi
+
+if [ -z "$cert_strict_sni" ] || [ "$cert_strict_sni" = "false" ];
+then
+	echo "Strict SNI not set. Keeping strict SNI disabled..."
+else
+	echo "Strict SNI set to ENABLED. Enabling Strict SNI."
+	echo "      sniStrict: true" >> /config/dynamic/ssl.yml
+fi
+
+# Setup services
+iocage exec "$1" sysrc "traefik_conf=/config/traefik.toml"
+iocage exec "$1" sysrc "traefik_enable=YES"
+iocage exec "$1" sysrc "firewall_script=/config/firewall.rules"
+iocage exec "$1" sysrc "firewall_enable=YES"
+iocage exec "$1" service ipfw start
+iocage exec "$1" service traefik start
+
+exitblueprint "${1}" "Traefik installed successfully, you can now connect to the traefik dashboard: https://${domain_name}"

--- a/blueprints/traefik/install.sh
+++ b/blueprints/traefik/install.sh
@@ -64,12 +64,11 @@ fi
 if [ -z "$dashboard" ] || [ "$dashboard" = "false" ];
 then
 	echo "dashboard disabled. Keeping the dashboard disabled..."
-	iocage exec "${1}" sed -i '' "s|dashplaceholder|${false}|" /config/traefik.toml
+	iocage exec "${1}" sed -i '' "s|dashplaceholder|false|" /config/traefik.toml
 else
 	echo "Dashboard set to on, enabling dashboard"
-	iocage exec "${1}" sed -i '' "s|dashplaceholder|${true}|" /config/traefik.toml
+	iocage exec "${1}" sed -i '' "s|dashplaceholder|true|" /config/traefik.toml
 fi
-dashplaceholder
 
 # Setup services
 iocage exec "$1" sysrc "traefik_conf=/config/traefik.toml"

--- a/blueprints/traefik/install.sh
+++ b/blueprints/traefik/install.sh
@@ -61,6 +61,16 @@ else
 	echo "      sniStrict: true" >> /config/dynamic/ssl.yml
 fi
 
+if [ -z "$dashboard" ] || [ "$dashboard" = "false" ];
+then
+	echo "dashboard disabled. Keeping the dashboard disabled..."
+	iocage exec "${1}" sed -i '' "s|dashplaceholder|${false}|" /config/traefik.toml
+else
+	echo "Dashboard set to on, enabling dashboard"
+	iocage exec "${1}" sed -i '' "s|dashplaceholder|${true}|" /config/traefik.toml
+fi
+dashplaceholder
+
 # Setup services
 iocage exec "$1" sysrc "traefik_conf=/config/traefik.toml"
 iocage exec "$1" sysrc "traefik_enable=YES"
@@ -69,4 +79,10 @@ iocage exec "$1" sysrc "firewall_enable=YES"
 iocage exec "$1" service ipfw start
 iocage exec "$1" service traefik start
 
-exitblueprint "${1}" "Traefik installed successfully, you can now connect to the traefik dashboard: https://${domain_name}"
+if [ -z "$dashboard" ] || [ "$dashboard" = "false" ];
+then
+	exitblueprint "${1}" "Traefik installed successfully, but you can not connect to the dashboard, as you had it disabled."
+else
+	exitblueprint "${1}" "Traefik installed successfully, you can now connect to the traefik dashboard: https://${domain_name}"
+fi
+

--- a/blueprints/traefik/readme.md
+++ b/blueprints/traefik/readme.md
@@ -1,0 +1,43 @@
+# Traefik 
+
+## Intro
+Traefik is a reverse proxy, this means it sits in-between your servers and the internet. Often these reverse proxies also, just like traefik, function as SSL endpoints, this means they encrypt the traffic comming from/to your servers.
+
+Standalone without docker Traefik is quite a challenge to setup right. JailMan tries to make it as easy as possible for your, by doing most of the groundwork and tweaking for you.
+This also means we don't support all features of traefik. We use traefik as a central reverse proxy and ssl termination endpoint for all our jails. Nothing more, Nothing less.
+
+To make things as streamlined as possible we had to make choices. Hence we only support DNS-verification for certificate generation. No http(s) verification is included.
+
+## Configuration Parameters
+
+Traefik requires a little more variables to setup in config.yml than other jails.
+Here is the list of configuration parameters:
+
+- dns_provider: The DNS provider you are using to verify ownership of the domain. This is required to get a letsencrypt certificate. We only support DNS-verification for certificate generation.
+- domain_name: The domain name you want to use to connect to traefik. Needs to be accessable at the DNS provider (cert_provider) with the DNS credentials (cert_env) provided.
+- cert_email: The email adress to link to the Lets Encrypt certificate
+- cert_env: For DNS verification we need login credentials and need to write those in a way Traefik understands. You can find the requirements for your DNS provider at the traefik website: https://docs.traefik.io/https/acme/
+You will need to use 2 spaces(!) in front and enter them below this configuration option. Like this:
+```
+	cert_env:
+	  CF_API_EMAIL: fake@email.adress
+	  CF_API_KEY: ftyhsfgufsgusfgjhsfghjsgfhj
+```
+
+### Advanced settings
+
+These settings are normally not required or normally used, but might come in handy for advanced users.
+- cert_staging: Set this to "true" if you want to test it out using the Lets Encrypt staging server. Set it to "false" or (preferable) just leave it out to use the production server.
+- cert_wildcard_domain: If you want to generate wildcard certificates, please enter the domain name here, without `*.` (ex. `test.testdomain.com`)
+- cert_strict_sni: set to "true" to enable strict SNI checking, set to false or (preferably) just leave it out to disable strict-SNI checking.
+
+
+## Installing
+
+Just do the usual install procedures, like any other JailMan jail.
+If you have done it right, you can reach the Traefik admin dashboard using the domain_name you entered in the config file.
+
+## Usages
+
+Currently we haven't migrated all jails to sit behind the traefik reverse proxy yet. We also didn't add security for the dashboard yet.
+Thus it is currently not usable out of the box, although the Traefik installation is fully configured.

--- a/blueprints/traefik/readme.md
+++ b/blueprints/traefik/readme.md
@@ -16,6 +16,7 @@ Here is the list of configuration parameters:
 - dns_provider: The DNS provider you are using to verify ownership of the domain. This is required to get a letsencrypt certificate. We only support DNS-verification for certificate generation.
 - domain_name: The domain name you want to use to connect to traefik. Needs to be accessable at the DNS provider (cert_provider) with the DNS credentials (cert_env) provided.
 - cert_email: The email adress to link to the Lets Encrypt certificate
+- dashboard: set to "true" to enable the dashboard.
 - cert_env: For DNS verification we need login credentials and need to write those in a way Traefik understands. You can find the requirements for your DNS provider at the traefik website: https://docs.traefik.io/https/acme/
 You will need to use 2 spaces(!) in front and enter them below this configuration option. Like this:
 ```
@@ -41,3 +42,5 @@ If you have done it right, you can reach the Traefik admin dashboard using the d
 
 Currently we haven't migrated all jails to sit behind the traefik reverse proxy yet. We also didn't add security for the dashboard yet.
 Thus it is currently not usable out of the box, although the Traefik installation is fully configured.
+
+Although the web interface shows port 9080 and 9443, Traefik is actually also listening on the (more common) port 80 and 443, also known as normal (without port in the URL) http and https ports.

--- a/blueprints/traefik/update.sh
+++ b/blueprints/traefik/update.sh
@@ -1,0 +1,6 @@
+#!/usr/local/bin/bash
+# This file contains an example update script to base your own jails on
+
+initblueprint "$1"
+#TODO insert code to update itself here
+

--- a/config.yml.example
+++ b/config.yml.example
@@ -120,3 +120,17 @@ jail:
     gateway: 192.168.1.1
     itunes_media: /mnt/itunes
 
+  traefik:
+    blueprint: traefik
+    ip4_addr: 192.168.1.250/24
+    gateway: 192.168.1.1
+	domain_name: traefik.test.placeholder.net
+	dns_provider: cloudflare
+	cert_staging: true
+	cert_email: fake@email.net
+	cert_wildcard_domain: test.placeholder.net
+	# Please follow the guide here: https://docs.traefik.io/https/acme/
+	# and enter your DNS providers environment variables below (2 spaces indent) of cert_env
+	cert_env:
+	  CF_API_EMAIL: fake@email.adress
+	  CF_API_KEY: ftyhsfgufsgusfgjhsfghjsgfhj

--- a/config.yml.example
+++ b/config.yml.example
@@ -124,6 +124,7 @@ jail:
     blueprint: traefik
     ip4_addr: 192.168.1.250/24
     gateway: 192.168.1.1
+	dashboard: true
 	domain_name: traefik.test.placeholder.net
 	dns_provider: cloudflare
 	cert_staging: true

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -78,6 +78,7 @@ Basic means: The same setup as a FreeNAS plugin would've, DHCP on bridge0.
 - nextcloud
 - bitwarden
 - unifi controller
+- traefik
 
 #### Backend
 - mariadb


### PR DESCRIPTION
# Pull Request Template
### Purpose
This PR adds traefik as a global reverse proxy.

Some notes:
- It should auto forward http to https (as it would, even without a valid cert) just use a self-signed one
- It should automatically get an A+ SSLlabs score
- Strict SNI should be an option
- Should be able to set lets-encrypt staging
- It should be able to get wildcard certs using letsencrypt
- It should be able to get custom (non wildcard) certs using letsencrypt
- It should be DNS verification compatible, with all supported DNS providers
- I don't give a flying f about lets encrypt http verification, DNS verification is free and the future, get over it.
- It should read a whole dynamic configs folder for jails to put their configs in.
- It should use (seperate) dynamic configs for every jail

### Notes:
It doesn't contain a few aspect that need to be added with a future patch:
- Support for the actual blueprints
- Support for some more (and custom) headers
- Support for basic auth and forward auth

### Please make sure you have followed the self checks below before submitting a PR:

- [X] Code is sufficiently commented
- [X] Code is indented with tabs and not spaces
- [X] The PR does not bring up any new errors
- [X] The PR has been tested
- [X] Any new files are named using lowercase (to avoid issues on case sensitive file systems)
