### PR TITLE
Fixup *arr versioning and updating

### DIFF
--- a/blueprints/jackett/install.sh
+++ b/blueprints/jackett/install.sh
@@ -10,7 +10,7 @@ DOWNLOAD=$(curl -s https://api.github.com/repos/Jackett/Jackett/releases/latest 
 
 iocage exec "${1}" fetch -o /usr/local/share "${DOWNLOAD}"
 iocage exec "$1" "tar -xzvf /usr/local/share/${FILE_NAME} -C /usr/local/share"
-iocage exec "$1" rm /usr/local/share/${FILE_NAME}
+iocage exec "$1" rm /usr/local/share/"${FILE_NAME}"
 iocage exec "$1" "pw user add jackett -c jackett -u 818 -d /nonexistent -s /usr/bin/nologin"
 iocage exec "$1" chown -R jackett:jackett /usr/local/share/Jackett /config
 iocage exec "$1" mkdir /usr/local/etc/rc.d

--- a/blueprints/jackett/install.sh
+++ b/blueprints/jackett/install.sh
@@ -5,10 +5,12 @@
 initblueprint "$1"
 
 # Initialise defaults
+FILE_NAME=$(curl -s https://api.github.com/repos/Jackett/Jackett/releases/latest | jq -r ".assets[] | select(.name | contains(\"Mono.tar.gz\")) | .name")
+DOWNLOAD=$(curl -s https://api.github.com/repos/Jackett/Jackett/releases/latest | jq -r ".assets[] | select(.name | contains(\"Mono.tar.gz\")) | .browser_download_url")
 
-iocage exec "$1" "fetch https://github.com/Jackett/Jackett/releases/download/v0.16.546/Jackett.Binaries.Mono.tar.gz -o /usr/local/share"
-iocage exec "$1" "tar -xzvf /usr/local/share/Jackett.Binaries.Mono.tar.gz -C /usr/local/share"
-iocage exec "$1" rm /usr/local/share/Jackett.Binaries.Mono.tar.gz
+iocage exec "${1}" fetch -o /usr/local/share "${DOWNLOAD}"
+iocage exec "$1" "tar -xzvf /usr/local/share/${FILE_NAME} -C /usr/local/share"
+iocage exec "$1" rm /usr/local/share/${FILE_NAME}
 iocage exec "$1" "pw user add jackett -c jackett -u 818 -d /nonexistent -s /usr/bin/nologin"
 iocage exec "$1" chown -R jackett:jackett /usr/local/share/Jackett /config
 iocage exec "$1" mkdir /usr/local/etc/rc.d

--- a/blueprints/jackett/update.sh
+++ b/blueprints/jackett/update.sh
@@ -5,9 +5,17 @@
 initblueprint "$1"
 
 # Initialise defaults
+FILE_NAME=$(curl -s https://api.github.com/repos/Jackett/Jackett/releases/latest | jq -r ".assets[] | select(.name | contains(\"Mono.tar.gz\")) | .name")
+DOWNLOAD=$(curl -s https://api.github.com/repos/Jackett/Jackett/releases/latest | jq -r ".assets[] | select(.name | contains(\"Mono.tar.gz\")) | .browser_download_url")
 
 iocage exec "$1" service jackett stop
-#TODO insert code to update jacket itself here
+
+rm -Rf /usr/local/share/jackett
+# Download and install the package
+iocage exec "${1}" fetch -o /usr/local/share "${DOWNLOAD}"
+iocage exec "$1" "tar -xzvf /usr/local/share/${FILE_NAME} -C /usr/local/share"
+iocage exec "$1" rm /usr/local/share/${FILE_NAME}
+
 iocage exec "$1" chown -R jackett:jackett /usr/local/share/Jackett /config
 cp "${SCRIPT_DIR}"/blueprints/jackett/includes/jackett.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/jackett
 iocage exec "$1" chmod u+x /usr/local/etc/rc.d/jackett

--- a/blueprints/jackett/update.sh
+++ b/blueprints/jackett/update.sh
@@ -10,8 +10,8 @@ DOWNLOAD=$(curl -s https://api.github.com/repos/Jackett/Jackett/releases/latest 
 
 iocage exec "$1" service jackett stop
 
-rm -Rf /usr/local/share/jackett
 # Download and install the package
+rm -Rf /usr/local/share/jackett
 iocage exec "${1}" fetch -o /usr/local/share "${DOWNLOAD}"
 iocage exec "$1" "tar -xzvf /usr/local/share/${FILE_NAME} -C /usr/local/share"
 iocage exec "$1" rm /usr/local/share/${FILE_NAME}

--- a/blueprints/jackett/update.sh
+++ b/blueprints/jackett/update.sh
@@ -14,7 +14,7 @@ iocage exec "$1" service jackett stop
 rm -Rf /usr/local/share/jackett
 iocage exec "${1}" fetch -o /usr/local/share "${DOWNLOAD}"
 iocage exec "$1" "tar -xzvf /usr/local/share/${FILE_NAME} -C /usr/local/share"
-iocage exec "$1" rm /usr/local/share/${FILE_NAME}
+iocage exec "$1" rm /usr/local/share/"${FILE_NAME}"
 
 iocage exec "$1" chown -R jackett:jackett /usr/local/share/Jackett /config
 cp "${SCRIPT_DIR}"/blueprints/jackett/includes/jackett.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/jackett

--- a/blueprints/lidarr/install.sh
+++ b/blueprints/lidarr/install.sh
@@ -5,6 +5,8 @@
 initblueprint "$1"
 
 # Initialise defaults
+FILE_NAME=$(curl -s https://api.github.com/repos/lidarr/Lidarr/releases | jq -r '[[.[] | select(.draft != true) | select(.prerelease == true)][0] | .assets | .[] | select(.name | endswith(".linux.tar.gz")) | .name][0]')
+DOWNLOAD=$(curl -s https://api.github.com/repos/lidarr/Lidarr/releases | jq -r '[[.[] | select(.draft != true) | select(.prerelease == true)][0] | .assets | .[] | select(.name | endswith(".linux.tar.gz")) | .browser_download_url][0]')
 
 # Check if dataset for completed download and it parent dataset exist, create if they do not.
 createmount "$1" "${global_dataset_downloads}"
@@ -13,11 +15,10 @@ createmount "$1" "${global_dataset_downloads}"/complete /mnt/fetched
 # Check if dataset for media library and the dataset for movies exist, create if they do not.
 createmount "$1" "${global_dataset_media}"
 createmount "$1" "${global_dataset_media}"/music /mnt/music
-
-
-iocage exec "$1" "fetch https://github.com/lidarr/Lidarr/releases/download/v0.7.1.1381/Lidarr.master.0.7.1.1381.linux.tar.gz -o /usr/local/share"
-iocage exec "$1" "tar -xzvf /usr/local/share/Lidarr.master.0.7.1.1381.linux.tar.gz -C /usr/local/share"
-iocage exec "$1" "rm /usr/local/share/Lidarr.master.0.7.1.1381.linux.tar.gz"
+  
+iocage exec "${1}" fetch -o /usr/local/share "${DOWNLOAD}"
+iocage exec "$1" "tar -xzvf /usr/local/share/${FILE_NAME} -C /usr/local/share"
+iocage exec "$1" rm /usr/local/share/${FILE_NAME}
 iocage exec "$1" "pw user add lidarr -c lidarr -u 353 -d /nonexistent -s /usr/bin/nologin"
 iocage exec "$1" chown -R lidarr:lidarr /usr/local/share/Lidarr /config
 iocage exec "$1" mkdir /usr/local/etc/rc.d

--- a/blueprints/lidarr/install.sh
+++ b/blueprints/lidarr/install.sh
@@ -18,7 +18,7 @@ createmount "$1" "${global_dataset_media}"/music /mnt/music
   
 iocage exec "${1}" fetch -o /usr/local/share "${DOWNLOAD}"
 iocage exec "$1" "tar -xzvf /usr/local/share/${FILE_NAME} -C /usr/local/share"
-iocage exec "$1" rm /usr/local/share/${FILE_NAME}
+iocage exec "$1" rm /usr/local/share/"${FILE_NAME}"
 iocage exec "$1" "pw user add lidarr -c lidarr -u 353 -d /nonexistent -s /usr/bin/nologin"
 iocage exec "$1" chown -R lidarr:lidarr /usr/local/share/Lidarr /config
 iocage exec "$1" mkdir /usr/local/etc/rc.d

--- a/blueprints/lidarr/update.sh
+++ b/blueprints/lidarr/update.sh
@@ -5,9 +5,17 @@
 initblueprint "$1"
 
 # Initialise defaults
+FILE_NAME=$(curl -s https://api.github.com/repos/lidarr/Lidarr/releases | jq -r '[[.[] | select(.draft != true) | select(.prerelease == true)][0] | .assets | .[] | select(.name | endswith(".linux.tar.gz")) | .name][0]')
+DOWNLOAD=$(curl -s https://api.github.com/repos/lidarr/Lidarr/releases | jq -r '[[.[] | select(.draft != true) | select(.prerelease == true)][0] | .assets | .[] | select(.name | endswith(".linux.tar.gz")) | .browser_download_url][0]')
 
 iocage exec "$1" service lidarr stop
-#TODO insert code to update lidarr itself here
+
+# Download and install the package
+rm -Rf /usr/local/share/jackett
+iocage exec "${1}" fetch -o /usr/local/share "${DOWNLOAD}"
+iocage exec "$1" "tar -xzvf /usr/local/share/${FILE_NAME} -C /usr/local/share"
+iocage exec "$1" rm /usr/local/share/${FILE_NAME}
+
 iocage exec "$1" chown -R lidarr:lidarr /usr/local/share/lidarr /config
 cp "${SCRIPT_DIR}"/blueprints/lidarr/includes/lidarr.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/lidarr
 iocage exec "$1" chmod u+x /usr/local/etc/rc.d/lidarr

--- a/blueprints/lidarr/update.sh
+++ b/blueprints/lidarr/update.sh
@@ -14,7 +14,7 @@ iocage exec "$1" service lidarr stop
 rm -Rf /usr/local/share/jackett
 iocage exec "${1}" fetch -o /usr/local/share "${DOWNLOAD}"
 iocage exec "$1" "tar -xzvf /usr/local/share/${FILE_NAME} -C /usr/local/share"
-iocage exec "$1" rm /usr/local/share/${FILE_NAME}
+iocage exec "$1" rm /usr/local/share/"${FILE_NAME}"
 
 iocage exec "$1" chown -R lidarr:lidarr /usr/local/share/lidarr /config
 cp "${SCRIPT_DIR}"/blueprints/lidarr/includes/lidarr.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/lidarr

--- a/blueprints/radarr/install.sh
+++ b/blueprints/radarr/install.sh
@@ -5,6 +5,8 @@
 initblueprint "$1"
 
 # Initialise defaults
+FILE_NAME=$(curl -s https://api.github.com/repos/Radarr/Radarr/releases | jq -r '[[.[] | select(.draft != true) | select(.prerelease == true)][0] | .assets | .[] | select(.name | endswith(".linux.tar.gz")) | .name][0]')
+DOWNLOAD=$(curl -s https://api.github.com/repos/Radarr/Radarr/releases | jq -r '[[.[] | select(.draft != true) | select(.prerelease == true)][0] | .assets | .[] | select(.name | endswith(".linux.tar.gz")) | .browser_download_url][0]')
 
 # Check if dataset for completed download and it parent dataset exist, create if they do not.
 createmount "$1" "${global_dataset_downloads}"
@@ -14,9 +16,9 @@ createmount "$1" "${global_dataset_downloads}"/complete /mnt/fetched
 createmount "$1" "${global_dataset_media}"
 createmount "$1" "${global_dataset_media}"/movies /mnt/movies
 
-iocage exec "$1" "fetch https://github.com/Radarr/Radarr/releases/download/v0.2.0.1480/Radarr.develop.0.2.0.1480.linux.tar.gz -o /usr/local/share"
-iocage exec "$1" "tar -xzvf /usr/local/share/Radarr.develop.0.2.0.1480.linux.tar.gz -C /usr/local/share"
-iocage exec "$1" rm /usr/local/share/Radarr.develop.0.2.0.1480.linux.tar.gz
+iocage exec "${1}" fetch -o /usr/local/share "${DOWNLOAD}"
+iocage exec "$1" "tar -xzvf /usr/local/share/${FILE_NAME} -C /usr/local/share"
+iocage exec "$1" rm /usr/local/share/"${FILE_NAME}"
 iocage exec "$1" "pw user add radarr -c radarr -u 352 -d /nonexistent -s /usr/bin/nologin"
 iocage exec "$1" chown -R radarr:radarr /usr/local/share/Radarr /config
 iocage exec "$1" mkdir /usr/local/etc/rc.d

--- a/blueprints/radarr/update.sh
+++ b/blueprints/radarr/update.sh
@@ -5,9 +5,17 @@
 initblueprint "$1"
 
 # Initialise defaults
+FILE_NAME=$(curl -s https://api.github.com/repos/Radarr/Radarr/releases | jq -r '[[.[] | select(.draft != true) | select(.prerelease == true)][0] | .assets | .[] | select(.name | endswith(".linux.tar.gz")) | .name][0]')
+DOWNLOAD=$(curl -s https://api.github.com/repos/Radarr/Radarr/releases | jq -r '[[.[] | select(.draft != true) | select(.prerelease == true)][0] | .assets | .[] | select(.name | endswith(".linux.tar.gz")) | .browser_download_url][0]')
 
 iocage exec "$1" service radarr stop
-#TODO insert code to update radarr itself here
+
+# Download and install the package
+rm -Rf /usr/local/share/radarr
+iocage exec "${1}" fetch -o /usr/local/share "${DOWNLOAD}"
+iocage exec "$1" "tar -xzvf /usr/local/share/${FILE_NAME} -C /usr/local/share"
+iocage exec "$1" rm /usr/local/share/"${FILE_NAME}"
+
 iocage exec "$1" chown -R radarr:radarr /usr/local/share/Radarr /config
 cp "${SCRIPT_DIR}"/blueprints/radarr/includes/radarr.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/radarr
 iocage exec "$1" chmod u+x /usr/local/etc/rc.d/radarr

--- a/blueprints/sonarr/update.sh
+++ b/blueprints/sonarr/update.sh
@@ -7,7 +7,12 @@ initblueprint "$1"
 # Initialise defaults
 
 iocage exec "$1" service sonarr stop
-#TODO insert code to update sonarr itself here
+
+iocage exec "$1" rm -Rf /usr/local/share/NzbDrone
+iocage exec "$1" "fetch http://download.sonarr.tv/v2/master/mono/NzbDrone.master.tar.gz -o /usr/local/share"
+iocage exec "$1" "tar -xzvf /usr/local/share/NzbDrone.master.tar.gz -C /usr/local/share"
+iocage exec "$1" rm /usr/local/share/NzbDrone.master.tar.gz
+
 iocage exec "$1" chown -R sonarr:sonarr /usr/local/share/NzbDrone /config
 cp "${SCRIPT_DIR}"/blueprints/sonarr/includes/sonarr.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/sonarr
 iocage exec "$1" chmod u+x /usr/local/etc/rc.d/sonarr


### PR DESCRIPTION
# Pull Request Template
### Purpose
Currently some of the *arr jails either don't update using the update script and/or don't auotmatically install using the newest version.

We should streamline this, as one of the selling points of Jailman, In contrast to plugins, is NOT relying on weither the plugin/blueprint version is up-to-date

### Notes:
Fixes #129
Fixes #128
Fixes #127

### Please make sure you have followed the self checks below before submitting a PR:

- [X] Code is sufficiently commented
- [X] Code is indented with tabs and not spaces
- [X] The PR does not bring up any new errors
- [x] The PR has been tested
- [X] Any new files are named using lowercase (to avoid issues on case sensitive file systems)
