### PR TITLE
Auto-connect grafana to unifi-poller data

### DIFF
--- a/blueprints/grafana/config.yml
+++ b/blueprints/grafana/config.yml
@@ -2,5 +2,5 @@ blueprint:
   grafana:
     traefik_service_port: 3000
     pkgs: grafana5
-    vars: link_influxdb datasource_name datasource_database datasource_user datasource_password password
+    vars: link_influxdb link_unifi password
     reqvars: password

--- a/blueprints/grafana/install.sh
+++ b/blueprints/grafana/install.sh
@@ -20,12 +20,16 @@ iocage exec "${1}" chown -R grafana:grafana /config
 
 # Setup connection to influxdb, if necessary
 if [ -n "${link_influxdb}" ]; then
-  cp "${includes_dir}"/influxdb.yaml /mnt/"${global_dataset_config}"/"${1}"/provisioning/datasources
-  iocage exec "${1}" sed -i '' "s|datasource_name|${datasource_name}|" /config/provisioning/datasources/influxdb.yaml
-  iocage exec "${1}" sed -i '' "s|influxdb_ip|${link_influxdb_jail_ip}|" /config/provisioning/datasources/influxdb.yaml
-  iocage exec "${1}" sed -i '' "s|datasource_db|${datasource_database}|" /config/provisioning/datasources/influxdb.yaml
-  iocage exec "${1}" sed -i '' "s|datasource_user|${datasource_user}|" /config/provisioning/datasources/influxdb.yaml
-  iocage exec "${1}" sed -i '' "s|datasource_pass|${datasource_password}|" /config/provisioning/datasources/influxdb.yaml
+	if [ -n "${link_unifi}" ]; then
+		cp "${includes_dir}"/influxdb.yaml /mnt/"${global_dataset_config}"/"${1}"/provisioning/datasources/unifi.yaml
+		iocage exec "${1}" sed -i '' "s|datasource_name|unifi|" /config/provisioning/datasources/unifi.yaml
+		iocage exec "${1}" sed -i '' "s|influxdb_ip|${link_influxdb_ip4_addr%/*}|" /config/provisioning/datasources/unifi.yaml
+		iocage exec "${1}" sed -i '' "s|datasource_db|${link_unifi_influxdb_database:-$link_unifi}|" /config/provisioning/datasources/unifi.yaml
+		iocage exec "${1}" sed -i '' "s|datasource_user|${link_unifi_influxdb_user:-$link_unifi}|" /config/provisioning/datasources/unifi.yaml
+		iocage exec "${1}" sed -i '' "s|datasource_pass|${link_unifi_influxdb_password:-}|" /config/provisioning/datasources/unifi.yaml
+	fi
+else
+	echo "Sorry, can't setup any grafana connections for you, as you didn't specify link_influxdb correctly..."
 fi
 
 # Set rc vars for startup and start grafana

--- a/blueprints/grafana/readme.md
+++ b/blueprints/grafana/readme.md
@@ -3,10 +3,7 @@
 #### Configuration Parameters
 - password (req): The password for the default admin account (admin). Required.
 - link_influxdb (opt): set to the name of the influxdb jail to set as datasource, if desired. 
-- datasource_name: Grafana's name of the datasource
-- datasource_database: name of the database in InfluxDB to connect to
-- datasource_user: the database user, if set
-- datasource_password: the database password, if set
+- link_unifi (opt): set to the name of the Unifi jail with Unifi Poller to automatically get its data from influxdb. (requires link_influxdb)
 
 ##### Datarsource options (opt) are only used if you wish to automatically connect Grafana to an InfluxDB data source (i.e. Unifi Poller).
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -12,114 +12,111 @@ global:
    downloads: tank/downloads
 
 jail:
-  plex:
+  plexjail:
     blueprint: plex
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
     beta: false
 
-  lidarr:
+  lidarrjail:
     blueprint: lidarr
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
 
-  sonarr:
+  sonarrjail:
     blueprint: sonarr
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
 
-  radarr:
+  radarrjail:
     blueprint: radarr
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
 
-  bazarr:
+  bazarrjail:
     blueprint: bazarr
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
 
-  kms:
+  kmsjail:
     blueprint: kms
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
 
-  jackett:
+  jackettjail:
     blueprint: jackett
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
 
-  organizr:
+  organizrjail:
     blueprint: organizr
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
 
-  tautulli:
+  tautullijail:
     blueprint: tautulli
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
 
-  transmission:
+  transmissionjail:
     blueprint: transmission
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
 
-  nextcloud:
+  nextcloudjail:
     blueprint: nextcloud
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
     time_zone: Europe/Amsterdam
     host_name: cloud.example.com
-    link_mariadb: "mariadb"
+    link_mariadb: mariadbjail
     admin_password: "PUTYOUROWNADMINPASSWORDHERE"
     mariadb_password: "PLEASEALSOPUTYOURPASSWORDHEREADIFFERNTONE"
 
-  mariadb:
+  mariadbjail:
     blueprint: mariadb
     ip4_addr: 192.168.1.98/24
     gateway: 192.168.1.1
     root_password: ReplaceThisWithYourOwnRootPAssword
     host_name: mariadb.local.example
 
-  bitwarden:
+  bitwardenjail:
     blueprint: bitwarden
     ip4_addr: 192.168.1.97/24
     gateway: 192.168.1.1
-    link_mariadb: "mariadb"
+    link_mariadb: mariadbjail
     mariadb_password: "YourDBPasswordHerePLEASE"
     admin_token: "PUTYOURADMINTOKENHEREANDREMOVETHIS"
 
-  influxdb:
+  influxdbjail:
     blueprint: influxdb
     ip4_addr: 192.168.1.250/24
     gateway: 192.168.1.1
 
-  unifi:
+  unifijail:
     blueprint: unifi
     ip4_addr: 192.168.1.251/24
     gateway: 192.168.1.1
     poller: true
-    link_influxdb: influxdb
+    link_influxdb: influxdbjail
     influxdb_password: unifi-poller
     poller_password: upoller
 
-  grafana:
+  grafanajail:
     blueprint: grafana
     ip4_addr: 192.168.1.100/24
     gateway: 192.168.1.1
     password: grafana
     link_influxdb: influxdbjail
-    datasource_name: Unifi Controller
-    datasource_database: unifi
-    datasource_user: unifi
-    datasource_password: unifi-poller
+    link_unifi: unifijail
 
-  forked_daapd:
+  forked_daapdjail:
     blueprint: forked_daapd
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1
     itunes_media: /mnt/itunes
 
-  traefik:
+  traefikjail:
     blueprint: traefik
     ip4_addr: 192.168.1.250/24
     gateway: 192.168.1.1
@@ -135,7 +132,7 @@ jail:
       CF_API_EMAIL: fake@email.adress
       CF_API_KEY: ftyhsfgufsgusfgjhsfghjsgfhj
 
-  sabnzbd:
+  sabnzbdjail:
     blueprint: sabnzbd
     ip4_addr: 192.168.1.99/24
     gateway: 192.168.1.1


### PR DESCRIPTION
# Pull Request Template
### Purpose
This PR replaces the "datasource" option, with a automated option to grab the unifi poller data from Influxdb

### Notes:
I completely removed the datasource option, because external sources can be added using the UI of grafana anyway and we don't actively support config parameters connecting to external services to keep things simple.
(I just removed those options from nextcloud to external mariadb for example)

### Please make sure you have followed the self checks below before submitting a PR:

- [X] Code is sufficiently commented
- [X] Code is indented with tabs and not spaces
- [x] The PR does not bring up any new errors
- [x] The PR has been tested
- [X] Any new files are named using lowercase (to avoid issues on case sensitive file systems)
