### PR TITLE
Traefik dynamic config generator

### DIFF
--- a/blueprints/bazarr/config.yml
+++ b/blueprints/bazarr/config.yml
@@ -1,3 +1,4 @@
 blueprint:
   bazarr: bazarr
+    traefik_service_port: 6767
     pkgs: git python3 py37-pip py37-libxml2 libxslt py37-sqlite3

--- a/blueprints/bazarr/install.sh
+++ b/blueprints/bazarr/install.sh
@@ -21,4 +21,4 @@ iocage exec "$1" chmod u+x /usr/local/etc/rc.d/bazarr
 iocage exec "$1" sysrc "bazarr_enable=YES"
 iocage exec "$1" service bazarr start
 
-exitblueprint "$1" "Bazarr is now accessible at http://${ip4_addr%/*}:6767"
+exitblueprint "$1"

--- a/blueprints/bitwarden/config.yml
+++ b/blueprints/bitwarden/config.yml
@@ -1,5 +1,6 @@
 blueprint:
   bitwarden:
+    traefik_service_port: 8000
     pkgs: git sudo bash node npm mariadb104-client
     vars: admin_token link_mariadb mariadb_database mariadb_user mariadb_password
     reqvars: ip4_addr link_mariadb mariadb_password

--- a/blueprints/bitwarden/install.sh
+++ b/blueprints/bitwarden/install.sh
@@ -51,7 +51,7 @@ if [ "${reinstall}" = "true" ]; then
 else
 	echo "No config detected, doing clean install, utilizing the Mariadb database ${DB_HOST}"
 	iocage exec "${link_mariadb}" mysql -u root -e "CREATE DATABASE ${mariadb_database};"
-	iocage exec "${link_mariadb}" mysql -u root -e "GRANT ALL ON ${mariadb_database}.* TO ${mariadb_user}@${ip4_addr%/*} IDENTIFIED BY '${mariadb_password}';"
+	iocage exec "${link_mariadb}" mysql -u root -e "GRANT ALL ON ${mariadb_database}.* TO ${mariadb_user}@${jail_ip} IDENTIFIED BY '${mariadb_password}';"
 	iocage exec "${link_mariadb}" mysqladmin reload
 fi
 
@@ -75,5 +75,5 @@ iocage exec "${1}" sysrc "bitwarden_enable=YES"
 iocage exec "${1}" service bitwarden restart
 
 
-exitblueprint "$1" "Bitwarden is now accessible at https://${ip4_addr%/*}:8000"
+exitblueprint "$1" "Bitwarden is now accessible at https://${jail_ip}:8000"
 echo "Admin Token is ${admin_token}"

--- a/blueprints/forked_daapd/config.yml
+++ b/blueprints/forked_daapd/config.yml
@@ -1,5 +1,6 @@
 blueprint:
   forked_daapd:
+    traefik_service_port: 3689
     pkgs: curl alsa-lib avahi avahi-libdns fontconfig fribidi gettext json-c libconfuse libevent libgcrypt libiconv libinotify libplist libsodium libsoxr libunistring libwebsockets nss_mdns openjdk8-jre pkgconf sqlite sqlite3
     vars: itunes_media
     reqvars: itunes_media

--- a/blueprints/forked_daapd/install.sh
+++ b/blueprints/forked_daapd/install.sh
@@ -49,7 +49,7 @@ if [ -z "${JAIL_IP}" ]; then
 	DEFAULT_IF=$(iocage exec "$1" route get default | awk '/interface/ {print $2}')
 	JAIL_IP=$(iocage exec "$1" ifconfig "$DEFAULT_IF" | awk '/inet/ { print $2 }')
 else
-	JAIL_IP=${ip4_addr%/*}
+	JAIL_IP=${jail_ip}
 fi
 
 exitblueprint "$1" "forked-daapd is available at http://${JAIL_IP}:3689/ and via daap."

--- a/blueprints/grafana/config.yml
+++ b/blueprints/grafana/config.yml
@@ -1,5 +1,6 @@
 blueprint:
   grafana:
+    traefik_service_port: 3000
     pkgs: grafana5
     vars: link_influxdb datasource_name datasource_database datasource_user datasource_password password
     reqvars: password

--- a/blueprints/grafana/install.sh
+++ b/blueprints/grafana/install.sh
@@ -22,7 +22,7 @@ iocage exec "${1}" chown -R grafana:grafana /config
 if [ -n "${link_influxdb}" ]; then
   cp "${includes_dir}"/influxdb.yaml /mnt/"${global_dataset_config}"/"${1}"/provisioning/datasources
   iocage exec "${1}" sed -i '' "s|datasource_name|${datasource_name}|" /config/provisioning/datasources/influxdb.yaml
-  iocage exec "${1}" sed -i '' "s|influxdb_ip|${link_influxdb_ip4_addr%/*}|" /config/provisioning/datasources/influxdb.yaml
+  iocage exec "${1}" sed -i '' "s|influxdb_ip|${link_influxdb_jail_ip}|" /config/provisioning/datasources/influxdb.yaml
   iocage exec "${1}" sed -i '' "s|datasource_db|${datasource_database}|" /config/provisioning/datasources/influxdb.yaml
   iocage exec "${1}" sed -i '' "s|datasource_user|${datasource_user}|" /config/provisioning/datasources/influxdb.yaml
   iocage exec "${1}" sed -i '' "s|datasource_pass|${datasource_password}|" /config/provisioning/datasources/influxdb.yaml
@@ -33,4 +33,4 @@ iocage exec "${1}" sysrc grafana_conf="/config/grafana.conf"
 iocage exec "${1}" sysrc grafana_enable="YES" 
 iocage exec "${1}" service grafana start
 
-exitblueprint "${1}" "Grafana is accessible at https://${ip4_addr%/*}:3000."
+exitblueprint "${1}"

--- a/blueprints/jackett/config.yml
+++ b/blueprints/jackett/config.yml
@@ -1,3 +1,4 @@
 blueprint:
   jackett:
+    traefik_service_port: 9117
     pkgs: mono

--- a/blueprints/jackett/install.sh
+++ b/blueprints/jackett/install.sh
@@ -19,4 +19,4 @@ iocage exec "$1" chmod u+x /usr/local/etc/rc.d/jackett
 iocage exec "$1" sysrc "jackett_enable=YES"
 iocage exec "$1" service jackett restart
 
-exitblueprint "$1" "Jackett is now accessible at http://${ip4_addr%/*}:9117"
+exitblueprint "$1"

--- a/blueprints/lidarr/config.yml
+++ b/blueprints/lidarr/config.yml
@@ -1,3 +1,4 @@
 blueprint:
   lidarr: lidarr
+    traefik_service_port: 8686
     pkgs: mono mediainfo sqlite3

--- a/blueprints/lidarr/install.sh
+++ b/blueprints/lidarr/install.sh
@@ -27,4 +27,4 @@ iocage exec "$1" chmod u+x /usr/local/etc/rc.d/lidarr
 iocage exec "$1" sysrc "lidarr_enable=YES"
 iocage exec "$1" service lidarr start
 
-exitblueprint "$1" "Lidarr is now accessible at http://${ip4_addr%/*}:8686"
+exitblueprint "$1"

--- a/blueprints/mariadb/config.yml
+++ b/blueprints/mariadb/config.yml
@@ -1,5 +1,6 @@
 blueprint:
   mariadb:
+    traefik_service_port: 80
     pkgs: mariadb104-server git  php74-session php74-xml php74-ctype php74-openssl php74-filter php74-gd php74-json php74-mysqli php74-mbstring php74-zlib php74-zip php74-bz2 phpMyAdmin5-php74 php74-pdo_mysql php74-mysqli phpMyAdmin5-php74
     vars: cert_email root_password
     reqvars: ip4_addr root_password host_name

--- a/blueprints/mariadb/install.sh
+++ b/blueprints/mariadb/install.sh
@@ -41,7 +41,7 @@ echo "Copying Caddyfile for no SSL"
 cp "${includes_dir}"/caddy.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/etc/rc.d/caddy
 cp "${includes_dir}"/Caddyfile /mnt/"${global_dataset_iocage}"/jails/"$1"/root/usr/local/www/Caddyfile
 iocage exec "${1}" sed -i '' "s/yourhostnamehere/${host_name}/" /usr/local/www/Caddyfile
-iocage exec "${1}" sed -i '' "s/JAIL-IP/${ip4_addr%/*}/" /usr/local/www/Caddyfile
+iocage exec "${1}" sed -i '' "s/JAIL-IP/${jail_ip}/" /usr/local/www/Caddyfile
 
 iocage exec "${1}" sysrc caddy_enable="YES"
 iocage exec "${1}" sysrc php_fpm_enable="YES"
@@ -70,7 +70,7 @@ iocage exec "${1}" sed -i '' "s|mypassword|${root_password}|" /root/.my.cnf
 # Save passwords for later reference
 iocage exec "${1}" echo "MariaDB root password is ${root_password}" > /root/"${1}"_root_password.txt
 
-exitblueprint "$1" "MariaDB is now accessible at http://${ip4_addr%/*}"
+exitblueprint "$1"
 echo "All passwords are saved in /root/${1}_db_password.txt"
 if [ "${reinstall}" = "true" ]; 
 then

--- a/blueprints/nextcloud/config.yml
+++ b/blueprints/nextcloud/config.yml
@@ -1,5 +1,6 @@
 blueprint:
   nextcloud:
+    traefik_service_port: 80
     pkgs:   nano sudo redis php73-ctype gnupg php73-dom php73-gd php73-iconv php73-json php73-mbstring php73-posix php73-simplexml php73-xmlreader php73-xmlwriter php73-zip php73-zlib php73-hash php73-xml php73 php73-pecl-redis php73-session php73-wddx php73-xsl php73-filter php73-pecl-APCu php73-curl php73-fileinfo php73-bz2 php73-intl php73-openssl php73-ldap php73-ftp php73-imap php73-exif php73-gmp php73-pecl-memcache php73-pecl-imagick php73-pecl-smbclient perl5 p5-Locale-gettext help2man texinfo m4 autoconf mariadb103-client php73-pdo_mysql php73-mysqli php73-opcache php73-pcntl php73-bcmath php73-pecl-APCu
     vars: time_zone cert_type cert_email dns_plugin dns_env link_mariadb mariadb_password mariadb_user mariadb_database admin_password
     reqvars: ip4_addr host_name admin_password time_zone link_mariadb mariadb_password

--- a/blueprints/nextcloud/install.sh
+++ b/blueprints/nextcloud/install.sh
@@ -132,7 +132,7 @@ cp "${includes_dir}"/caddy.rc /mnt/"${global_dataset_iocage}"/jails/"$1"/root/us
 
 iocage exec "${1}" sed -i '' "s/yourhostnamehere/${host_name}/" /usr/local/www/Caddyfile
 iocage exec "${1}" sed -i '' "s/DNS-PLACEHOLDER/${DNS_SETTING}/" /usr/local/www/Caddyfile
-iocage exec "${1}" sed -i '' "s/JAIL-IP/${ip4_addr%/*}/" /usr/local/www/Caddyfile
+iocage exec "${1}" sed -i '' "s/JAIL-IP/${jail_ip}/" /usr/local/www/Caddyfile
 iocage exec "${1}" sed -i '' "s|mytimezone|${time_zone}|" /usr/local/etc/php.ini
 
 iocage exec "${1}" sysrc caddy_enable="YES"
@@ -148,7 +148,7 @@ else
 	
 	# Secure database, create Nextcloud DB, user, and password
 	iocage exec "mariadb" mysql -u root -e "CREATE DATABASE ${mariadb_database};"
-	iocage exec "mariadb" mysql -u root -e "GRANT ALL ON ${mariadb_database}.* TO ${mariadb_user}@${ip4_addr%/*} IDENTIFIED BY '${mariadb_password}';"
+	iocage exec "mariadb" mysql -u root -e "GRANT ALL ON ${mariadb_database}.* TO ${mariadb_user}@${jail_ip} IDENTIFIED BY '${mariadb_password}';"
 	iocage exec "mariadb" mysqladmin reload
 	
 	
@@ -180,7 +180,7 @@ else
 	iocage exec "${1}" su -m www -c 'php /usr/local/www/nextcloud/occ config:system:set htaccess.RewriteBase --value="/"'
 	iocage exec "${1}" su -m www -c 'php /usr/local/www/nextcloud/occ maintenance:update:htaccess'
 	iocage exec "${1}" su -m www -c "php /usr/local/www/nextcloud/occ config:system:set trusted_domains 1 --value=\"${host_name}\""
-	iocage exec "${1}" su -m www -c "php /usr/local/www/nextcloud/occ config:system:set trusted_domains 2 --value=\"${ip4_addr%/*}\""
+	iocage exec "${1}" su -m www -c "php /usr/local/www/nextcloud/occ config:system:set trusted_domains 2 --value=\"${jail_ip}\""
 	iocage exec "${1}" su -m www -c 'php /usr/local/www/nextcloud/occ app:enable encryption'
 	iocage exec "${1}" su -m www -c 'php /usr/local/www/nextcloud/occ encryption:enable'
 	iocage exec "${1}" su -m www -c 'php /usr/local/www/nextcloud/occ encryption:disable'

--- a/blueprints/organizr/config.yml
+++ b/blueprints/organizr/config.yml
@@ -1,3 +1,4 @@
 blueprint:
   organizr:
+    traefik_service_port: 80
     pkgs: nginx php74 php74-filter php74-curl php74-hash php74-json php74-openssl php74-pdo php74-pdo_sqlite php74-session php74-simplexml php74-sqlite3 php74-zip git

--- a/blueprints/organizr/install.sh
+++ b/blueprints/organizr/install.sh
@@ -36,5 +36,5 @@ iocage exec "$1" sysrc php_fpm_enable=YES
 iocage exec "$1" service nginx start
 iocage exec "$1" service php-fpm start
 
-exitblueprint "$1" "Organizr is now accessible at http://${ip4_addr%/*}"
+exitblueprint "$1"
 

--- a/blueprints/plex/config.yml
+++ b/blueprints/plex/config.yml
@@ -1,4 +1,5 @@
 blueprint:
   plex:
+    traefik_service_port: 32400
     pkgs: plexmediaserver
     vars: beta ramdisk

--- a/blueprints/plex/install.sh
+++ b/blueprints/plex/install.sh
@@ -49,4 +49,4 @@ else
 	iocage exec "$1" service plexmediaserver restart
 fi
 
-exitblueprint "$1" "Plex is now accessible at https://${ip4_addr%/*}:32400/web/"
+exitblueprint "$1" "Plex is now accessible at https://${jail_ip}:32400/web/"

--- a/blueprints/radarr/config.yml
+++ b/blueprints/radarr/config.yml
@@ -1,3 +1,4 @@
 blueprint:
   radarr:
+    traefik_service_port: 7878
     pkgs: mono mediainfo sqlite3 libgdiplus

--- a/blueprints/radarr/install.sh
+++ b/blueprints/radarr/install.sh
@@ -27,4 +27,4 @@ iocage exec "$1" chmod u+x /usr/local/etc/rc.d/radarr
 iocage exec "$1" sysrc "radarr_enable=YES"
 iocage exec "$1" service radarr restart
 
-exitblueprint "$1" "Radarr is now accessible at http://${ip4_addr%/*}:7878"
+exitblueprint "$1"

--- a/blueprints/sabnzbd/config.yml
+++ b/blueprints/sabnzbd/config.yml
@@ -1,3 +1,4 @@
 blueprint:
   sabnzbd:
+    traefik_service_port: 8080
     pkgs: sabnzbdplus

--- a/blueprints/sabnzbd/install.sh
+++ b/blueprints/sabnzbd/install.sh
@@ -24,4 +24,4 @@ iocage exec "$1" sed -i '' -e 's?complete_dir = Downloads/complete?complete_dir 
 
 iocage exec "$1" service sabnzbd start
 
-exitblueprint "$1" "sabnzbd is now accessible at http://${jail_ip}:8080/"
+exitblueprint "$1"

--- a/blueprints/sonarr/config.yml
+++ b/blueprints/sonarr/config.yml
@@ -1,3 +1,4 @@
 blueprint:
   sonarr:
+    traefik_service_port: 8989
     pkgs: mono mediainfo sqlite3

--- a/blueprints/sonarr/install.sh
+++ b/blueprints/sonarr/install.sh
@@ -25,4 +25,4 @@ iocage exec "$1" chmod u+x /usr/local/etc/rc.d/sonarr
 iocage exec "$1" sysrc "sonarr_enable=YES"
 iocage exec "$1" service sonarr restart
 
-exitblueprint "$1" "Sonarr is now accessible at http://${ip4_addr%/*}:8989"
+exitblueprint "$1"

--- a/blueprints/tautulli/config.yml
+++ b/blueprints/tautulli/config.yml
@@ -1,3 +1,4 @@
 blueprint:
   tautulli:
+    traefik_service_port: 8181
     pkgs: python2 py27-sqlite3 py27-openssl git

--- a/blueprints/tautulli/install.sh
+++ b/blueprints/tautulli/install.sh
@@ -15,4 +15,4 @@ iocage exec "$1" sysrc "tautulli_enable=YES"
 iocage exec "$1" sysrc "tautulli_flags=--datadir /config"
 iocage exec "$1" service tautulli start
 
-exitblueprint "$1" "Tautulli is now accessible at http://${ip4_addr%/*}:8181"
+exitblueprint "$1"

--- a/blueprints/traefik/includes/buildin_middlewares.toml
+++ b/blueprints/traefik/includes/buildin_middlewares.toml
@@ -1,0 +1,7 @@
+[http]
+    # Redirect to https
+    [http.middlewares]
+      [http.middlewares.redirect-to-https.redirectScheme]
+        scheme = "https"
+	  [http.middlewares.retry.retry]
+        attempts = 3

--- a/blueprints/traefik/includes/dashboard.toml
+++ b/blueprints/traefik/includes/dashboard.toml
@@ -1,15 +1,10 @@
 [http]
-    # Redirect to https
-    [http.middlewares]
-      [http.middlewares.redirect-to-https.redirectScheme]
-        scheme = "https"
-
     [http.routers]
        [http.routers.http-catchall]
           rule = "hostregexp(`{host:.+}`)"
           service = "api@internal"
           entryPoints = ["web"]
-		  middlewares = "redirect-to-https"
+		  middlewares = ["redirect-to-https"]
        [http.routers.traefik]
           rule = "Host(`placeholderdashboardhost`)"
           service = "api@internal"

--- a/blueprints/traefik/includes/dashboard_wildcard.toml
+++ b/blueprints/traefik/includes/dashboard_wildcard.toml
@@ -1,10 +1,10 @@
 [http]
-    # Redirect to https
-    [http.middlewares]
-      [http.middlewares.redirect-to-https.redirectScheme]
-        scheme = "https"
-
     [http.routers]
+       [http.routers.http-catchall]
+          rule = "hostregexp(`{host:.+}`)"
+          service = "api@internal"
+          entryPoints = ["web"]
+		  middlewares = ["redirect-to-https"]
        [http.routers.traefik]
           rule = "Host(`placeholderdashboardhost`)"
           service = "api@internal"

--- a/blueprints/traefik/includes/default.toml
+++ b/blueprints/traefik/includes/default.toml
@@ -10,4 +10,4 @@
     [http.services]
         [http.services.placeholdername.loadbalancer]
             [[http.services.placeholdername.loadbalancer.servers]]
-                url = "placeholderurl"
+                url = "http://placeholderurl"

--- a/blueprints/traefik/includes/default.toml
+++ b/blueprints/traefik/includes/default.toml
@@ -1,0 +1,13 @@
+[http]
+    [http.routers]
+       [http.routers.placeholdername]
+          rule = "Host(`placeholderdashboardhost`)"
+          service = "placeholdername"
+          entryPoints = ["web-secure"]
+		  middlewares = ["retry"]
+        [http.routers.placeholdername.tls]
+          certResolver = "default" # From static configuration
+    [http.services]
+        [http.services.placeholdername.loadbalancer]
+            [[http.services.placeholdername.loadbalancer.servers]]
+                url = "placeholderurl"

--- a/blueprints/traefik/includes/default_auth_basic.toml
+++ b/blueprints/traefik/includes/default_auth_basic.toml
@@ -1,0 +1,3 @@
+[http.middlewares]
+  [http.middlewares.placeholdername-basic-auth.basicAuth]
+   users = [placeholderusers]

--- a/blueprints/traefik/includes/default_auth_forward.toml
+++ b/blueprints/traefik/includes/default_auth_forward.toml
@@ -1,0 +1,3 @@
+[http.middlewares]
+  [http.middlewares.placeholdername-forward-auth.forwardAuth]
+    address = "placeholderauthforward"

--- a/blueprints/traefik/install.sh
+++ b/blueprints/traefik/install.sh
@@ -11,11 +11,13 @@ productionurl="https://acme-v02.api.letsencrypt.org/directory"
 stagingurl="https://acme-staging-v02.api.letsencrypt.org/directory"
 
 # Copy the needed config files
+iocage exec "${1}" mkdir /config/temp/
 iocage exec "${1}" mkdir /config/dynamic/
 cp "${includes_dir}"/traefik.toml /mnt/"${global_dataset_config}"/"${1}"/
 cp "${includes_dir}"/firewall.rules /mnt/"${global_dataset_config}"/"${1}"/
 cp "${includes_dir}"/ssl.yml /mnt/"${global_dataset_config}"/"${1}"/dynamic/
 
+cp "${includes_dir}"/buildin_middlewares.toml /mnt/"${global_dataset_config}"/"${1}"/dynamic/buildin_middlewares.toml
 if [ -z "$cert_wildcard_domain" ];
 then
 	echo "wildcard not set, using non-wildcard config..."

--- a/blueprints/transmission/config.yml
+++ b/blueprints/transmission/config.yml
@@ -1,3 +1,4 @@
 blueprint:
   transmission:
+    traefik_service_port: 9091
     pkgs: bash unzip unrar transmission

--- a/blueprints/transmission/install.sh
+++ b/blueprints/transmission/install.sh
@@ -22,4 +22,4 @@ iocage exec "$1" sysrc "transmission_conf_dir=/config"
 iocage exec "$1" sysrc "transmission_download_dir=/mnt/downloads/complete"
 iocage exec "$1" service transmission restart
 
-exitblueprint "$1" "Transmission is now accessible at http://${ip4_addr%/*}:9091"
+exitblueprint "$1"

--- a/blueprints/unifi/config.yml
+++ b/blueprints/unifi/config.yml
@@ -1,5 +1,6 @@
 blueprint:
   unifi:
     pkgs: jq unifi5
+    traefik_service_port: 8443
     vars: link_influxdb unifi_poller influxdb_database influxdb_user influxdb_password poller_user poller_password
     reqvars: 

--- a/blueprints/unifi/install.sh
+++ b/blueprints/unifi/install.sh
@@ -88,5 +88,5 @@ else
   echo "In Grafana, add Unifi-Poller as a data source."
 fi
 
-exitblueprint "$1" "Unifi Controller is now accessible at https://${ip4_addr%/*}:8443"
+exitblueprint "$1" "Unifi Controller is now accessible at https://${jail_ip}:8443"
 

--- a/includes/global.sh
+++ b/includes/global.sh
@@ -215,12 +215,14 @@ if [ "${traefikstatus}" = "preinstalled" ]; then
 	# also replace auth related placeholders, because they can be part of custom config files
 	sed -i '' "s|placeholderusers|${traefik_auth_basic//&/\\&}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml
 	sed -i '' "s|placeholderauthforward|${traefik_auth_forward//&/\\&}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml
-	if [ -n "${traefik_auth_basic}" ] && [ -n "${traefik_auth_basic}" ]; then 
+	if [ -n "${traefik_auth_forward}" ] && [ -n "${traefik_auth_basic}" ]; then 
 		echo "cant setup traefik with both basic AND forward auth. Please pick one only."
 	elif [ -n "${traefik_auth_basic}" ]; then 
 		echo "Adding basic auth to Traefik for jail ${1}"
+		users="$(sed 's/[^[:space:]]\{1,\}/"&"/g;s/ /,/g' <<<"${traefik_auth_basic}")"
+		cp "${traefikincludes}"/default_auth_basic.toml /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}"_auth_basic.toml
 		sed -i '' "s|placeholdername|${1//&/\\&}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}"_auth_basic.toml
-		sed -i '' "s|placeholderusers|${traefik_auth_basic//&/\\&}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}"_auth_basic.toml
+		sed -i '' "s|placeholderusers|${users//&/\\&}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}"_auth_basic.toml
 		mv /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}"_auth_basic.toml /mnt/"${global_dataset_config}"/"${link_traefik}"/dynamic/"${1}"_auth_basic.toml
 		sed -i '' "s|\"retry\"|\"retry\",\"${1//&/\\&}-basic-auth\"|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml
 		traefikstatus="success"

--- a/includes/global.sh
+++ b/includes/global.sh
@@ -171,6 +171,17 @@ initblueprint() {
 }
 export -f initblueprint
 
+cleanupblueprint() {
+	link_traefik="jail_${1}_link_traefik"
+	link_traefik="${!link_traefik:-}"
+	if [ -n "${link_traefik}" ]; then
+		echo "removing remains..."
+		rm -f /mnt/"${global_dataset_config}"/"${link_traefik}"/dynamic/"${1}".toml
+		rm -f /mnt/"${global_dataset_config}"/"${link_traefik}"/dynamic/"${1}"_auth_basic.toml
+		rm -f /mnt/"${global_dataset_config}"/"${link_traefik}"/dynamic/"${1}"_auth_forward.toml
+	fi
+}
+export -f initblueprint
 
 exitblueprint() {
 blueprint="jail_${1}_blueprint" 

--- a/includes/global.sh
+++ b/includes/global.sh
@@ -173,17 +173,87 @@ export -f initblueprint
 
 
 exitblueprint() {
-blueprint=jail_${1}_blueprint
-echo "DO NOT DELETE THIS FILE" >> "/mnt/${global_dataset_config}/${1}/INSTALLED"
-echo "Jail $1 using blueprint ${!blueprint}, installed successfully."
-if [[ ! "${2}" ]]; then
- echo "Please consult the wiki for instructions connecting to your newly installed jail"
+blueprint="jail_${1}_blueprint" 
+traefik_service_port=" blueprint_${blueprint}_traefik_service_port"
+traefik_service_port="${traefik_service_port}"
+traefikincludes="${SCRIPT_DIR}/blueprints/traefik/includes"
+traefikstatus=""
+
+# Check if the jail is compatible with Traefik and copy the right default-config for the job.
+if [ -z "${link_traefik}" ] || [ -z "${ip4_addr}" ]; then
+	echo "Traefik-connection not enabled... Skipping connecting this jail to traefik"
 else
- echo ${2}
+	echo "removing old traefik config..."
+	rm -f /mnt/"${global_dataset_config}"/"${link_traefik}"/dynamic/"${1}".toml
+	rm -f /mnt/"${global_dataset_config}"/"${link_traefik}"/dynamic/"${1}"_auth_basic.toml
+	rm -f /mnt/"${global_dataset_config}"/"${link_traefik}"/dynamic/"${1}"_auth_forward.toml
+	if [ -z "${domain_name}" ]; then
+		echo "domain_name required for connecting to traefik... please add domain_name to config.yml"
+	elif [ -f "/mnt/${global_dataset_config}/${1}/traefik_custom.toml" ]; then
+		echo "Found custom traefik configuration... Copying to traefik..."
+		cp "${includes_dir}"/traefik_custom.toml /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml
+		traefikstatus="success"
+	elif [ -f "${includes_dir}/traefik_custom.toml" ]; then
+		echo "Found default traefik configuration for this blueprint... Copying to traefik..."
+		cp "${includes_dir}"/traefik_custom.toml /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml
+		traefikstatus="preinstalled"
+	elif [ -z "${traefik_service_port}" ]; then 
+		echo "Can't connect this jail to traefik... Please add a traefik_service_port to this jail in config.yml..."
+	else
+		echo "No custom traefik configuration found, using default..."
+		cp "${traefikincludes}"/default.toml /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml
+		traefikstatus="preinstalled"
+	fi
 fi
 
+# If the default config requires post-processing (it always does except for user-custom config in /config), do the post processing.
+if [ "${traefikstatus}" = "preinstalled" ]; then
+	# replace placeholder values.
+	sed -i '' "s|placeholderdashboardhost|${domain_name}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml
+	sed -i '' "s|placeholdername|${1}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml
+	sed -i '' "s|placeholderurl|${jail_ip}:${traefik_service_port}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml
+	# also replace auth related placeholders, because they can be part of custom config files
+	sed -i '' "s|placeholderusers|${traefik_auth_basic}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml
+	sed -i '' "s|placeholderauthforward|${traefik_auth_forward}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml
+	mv /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}".toml /mnt/"${global_dataset_config}"/"${link_traefik}"/dynamic/"${1}".toml
+	if [ -n "${traefik_auth_basic}" ] && [ -n "${traefik_auth_basic}" ]; then 
+		echo "cant setup traefik with both basic AND forward auth. Please pick one only."
+	elif [ -n "${traefik_auth_basic}" ]; then 
+		echo "Adding basic auth to Traefik for jail ${1}"
+		echo "" >> /mnt/"${global_dataset_config}"/"${link_traefik}"/auth/"${1}"_users.auth
+		sed -i '' "s|placeholdername|${1}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}"_auth_basic.toml
+		sed -i '' "s|placeholderusers|${traefik_auth_basic}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}"_auth_basic.toml
+		mv /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}"_auth_basic.toml /mnt/"${global_dataset_config}"/"${link_traefik}"/dynamic/"${1}"_auth_basic.toml
+		traefikstatus="success"
+	elif [ -n "${traefik_auth_forward}" ]; then 
+		echo "Adding basic auth to Traefik for jail ${1}"
+		cp "${traefikincludes}"/default_auth_forward.toml /mnt/"${global_dataset_config}"/"${link_traefik}"/dynamic/"${1}"_auth_forward.toml
+		sed -i '' "s|placeholdername|${1}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}"_auth_basic.toml
+		sed -i '' "s|placeholderauthforward|${traefik_auth_forward}|" /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}"_auth_basic.toml
+		mv /mnt/"${global_dataset_config}"/"${link_traefik}"/temp/"${1}"_auth_forward.toml /mnt/"${global_dataset_config}"/"${link_traefik}"/dynamic/"${1}"_auth_forward.toml
+		traefikstatus="success"
+	else
+		echo "No auth specified, setting up traefik without auth..."
+	fi
+fi
+
+# Add a file to flag the jail is INSTALLED and thus trigger reinstall on next install
+echo "DO NOT DELETE THIS FILE" >> "/mnt/${global_dataset_config}/${1}/INSTALLED"
+echo "Jail $1 using blueprint ${!blueprint}, installed successfully."
+
+# Pick the right success message to hint to user how to connect to the jail
+if [ "${traefikstatus}" = "success" ]; then
+	echo "Your jail ${1} running ${!blueprint} is now accessible via Traefik at https://${domain_name}"
+elif [[ ! "${2}" ]]; then
+	echo " ${2}"
+elif [ -n "${traefik_service_port}" ]; then
+	echo "Your jail ${1} running ${!blueprint} is now accessible at http://${jail_ip}:${traefik_service_port}"
+else
+	echo "Please consult the wiki for instructions connecting to your newly installed jail"
+fi
 }
 export -f exitblueprint
+
 
 createmount() {
 	jail=${1:-}

--- a/includes/global.yml
+++ b/includes/global.yml
@@ -5,5 +5,5 @@ global:
    # Global pkgs to install in all jails.
    # Please use standard space delimited pkg install syntax.
    pkgs: curl ca_root_nss bash
-   vars: ip4_addr host_name gateway
+   vars: ip4_addr host_name gateway link_traefik domain_name traefik_service_port traefik_auth_basic traefik_auth_forward
    reqvars: 

--- a/jailman.sh
+++ b/jailman.sh
@@ -124,8 +124,8 @@ else
 	echo "jails to destroy ${destroyjails[@]}"
 	for jail in "${destroyjails[@]}"
 	do
-		echo "destroying $jail"
 		iocage destroy -f "${jail}"
+		cleanupblueprint "${jail}"
 	done
 
 fi
@@ -170,7 +170,7 @@ else
 		elif [ -f "${SCRIPT_DIR}/blueprints/${!blueprint}/install.sh" ]
 		then
 			echo "Reinstalling $jail"
-			iocage destroy -f "${jail}" && jailcreate "${jail}" "${!blueprint}" && "${SCRIPT_DIR}"/blueprints/"${!blueprint}"/install.sh "${jail}"
+			iocage destroy -f "${jail}" && cleanupblueprint "${jail}" && jailcreate "${jail}" "${!blueprint}" && "${SCRIPT_DIR}"/blueprints/"${!blueprint}"/install.sh "${jail}"
 		else
 			echo "Missing blueprint ${!blueprint} for $jail in ${SCRIPT_DIR}/blueprints/${!blueprint}/install.sh"
 			exit 1


### PR DESCRIPTION
# Pull Request Template
### Purpose
This PR aims to implement traefik into all blueprint creation processes (on exit that is). It should keep the requirements for blueprint creators and users creating their config.yml file to a minimum

### Notes:

**There will be 3 types of config:**
1. Defaultauto-generation template (based on what you enter in the config file)
2. Custom auto-generation template (based on what you enter in the config file, but customised for a specific blueprint)
3. Fully custom config, writhen by the user

The priority goes from 3->2->1.
So if there is an fully custom user-made config available thats used, if there is a custom auto-generation template available that is being used and last (if no other is available) it is using the default template.

**Adding jails to traefik**
Adding jails to to traefik will be gosh damn easy.
It requires 3 things for the user:
- A fixed IP
- link_traefik with the name of the traefikjail
- domain_name filled with a domainname that is available using your traefik DNS provider

As we advice using fixed IP's already, for most users it just means entering a valid domain_name and link_traefik.

**Adding basic auth to jails**
Once jails are added to traefik, adding basic auth is a breeze. Space seperated, with a : between username and a hashed password, just add:
traefik_auth_basic: username1:passwordhash1 username2:passwordhash2

In the future we might automate hashing, on the other hand it might be saver NOT to use plaintext passwords when traefik already tries to prevent us from using those.

**Adding forward auth to jails**
This is even simpler than basic auth and we will supply the right config to set this up with Organizr in the readme:
traefik_auth_forward: http://urltoforward.to/auth

### Not included in this PR
- Removal of (self-signed) https from the blueprints (this will be future patches)
- Writing custom traefik templates for blueprints that need it
- Documentation, this should be done after we are sure all blueprints are either compatible or include custom config

### How to test
This PR can be tested using jails that serve a "simple" website over http.
Example:
- jackett
- radarr
- sonarr
- lidarr

A full round of compatibility testing an patching is (as stated in the "not included" section) to-be-done in a future PR.

### Please make sure you have followed the self checks below before submitting a PR:

- [X] Code is sufficiently commented
- [X] Code is indented with tabs and not spaces
- [X] The PR does not bring up any new errors
- [X] The PR has been tested
- [X] Any new files are named using lowercase (to avoid issues on case sensitive file systems)
