### PR TITLE
Cleanup and Simplification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /config.yml
 /tmp/
+/summaries/

--- a/config.yml.example
+++ b/config.yml.example
@@ -11,135 +11,133 @@ global:
     # (is going to contain: Complete and Incomplete datasets for downloads)
     downloads: tank/downloads
 
-jail:
-  plexjail:
-    blueprint: plex
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
-    beta: false
+plexjail:
+  blueprint: plex
+  ip4_addr: 192.168.1.200/24
+  gateway: 192.168.1.1
 
-  lidarrjail:
-    blueprint: lidarr
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
+lidarrjail:
+  blueprint: lidarr
+  ip4_addr: 192.168.1.201/24
+  gateway: 192.168.1.1
 
-  sonarrjail:
-    blueprint: sonarr
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
+sonarrjail:
+  blueprint: sonarr
+  ip4_addr: 192.168.1.202/24
+  gateway: 192.168.1.1
 
-  radarrjail:
-    blueprint: radarr
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
+radarrjail:
+  blueprint: radarr
+  ip4_addr: 192.168.1.203/24
+  gateway: 192.168.1.1
 
-  bazarrjail:
-    blueprint: bazarr
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
+bazarrjail:
+  blueprint: bazarr
+  ip4_addr: 192.168.1.204/24
+  gateway: 192.168.1.1
 
-  kmsjail:
-    blueprint: kms
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
+kmsjail:
+  blueprint: kms
+  ip4_addr: 192.168.1.205/24
+  gateway: 192.168.1.1
 
-  jackettjail:
-    blueprint: jackett
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
+jackettjail:
+  blueprint: jackett
+  ip4_addr: 192.168.1.206/24
+  gateway: 192.168.1.1
 
-  organizrjail:
-    blueprint: organizr
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
+organizrjail:
+  blueprint: organizr
+  ip4_addr: 192.168.1.207/24
+  gateway: 192.168.1.1
 
-  tautullijail:
-    blueprint: tautulli
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
+tautullijail:
+  blueprint: tautulli
+  ip4_addr: 192.168.1.208/24
+  gateway: 192.168.1.1
 
-  transmissionjail:
-    blueprint: transmission
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
+transmissionjail:
+  blueprint: transmission
+  ip4_addr: 192.168.1.209/24
+  gateway: 192.168.1.1
 
-  nextcloudjail:
-    blueprint: nextcloud
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
-    time_zone: Europe/Amsterdam
-    domain_name: cloud.example.com
-    link_mariadb: mariadbjail
-    admin_password: "PUTYOUROWNADMINPASSWORDHERE"
-    mariadb_password: "PLEASEALSOPUTYOURPASSWORDHEREADIFFERNTONE"
+nextcloudjail:
+  blueprint: nextcloud
+  ip4_addr: 192.168.1.210/24
+  gateway: 192.168.1.1
+  time_zone: Europe/Amsterdam
+  domain_name: cloud.example.com
+  link_mariadb: mariadbjail
+  admin_password: "PUTYOUROWNADMINPASSWORDHERE"
+  mariadb_password: "PLEASEALSOPUTYOURPASSWORDHEREADIFFERNTONE"
 
 
-  mariadbjail:
-    blueprint: mariadb
-    ip4_addr: 192.168.1.98/24
-    gateway: 192.168.1.1
-    root_password: ReplaceThisWithYourOwnRootPAssword
-    domain_name: mariadb.local.example
+mariadbjail:
+  blueprint: mariadb
+  ip4_addr: 192.168.1.211/24
+  gateway: 192.168.1.1
+  root_password: ReplaceThisWithYourOwnRootPAssword
+  domain_name: mariadb.local.example
 
-  bitwardenjail:
-    blueprint: bitwarden
-    ip4_addr: 192.168.1.97/24
-    gateway: 192.168.1.1
-    link_mariadb: mariadbjail
-    mariadb_password: "YourDBPasswordHerePLEASE"
-    admin_token: "PUTYOURADMINTOKENHEREANDREMOVETHIS"
+bitwardenjail:
+  blueprint: bitwarden
+  ip4_addr: 192.168.1.212/24
+  gateway: 192.168.1.1
+  link_mariadb: mariadbjail
+  mariadb_password: "YourDBPasswordHerePLEASE"
+  admin_token: "PUTYOURADMINTOKENHEREANDREMOVETHIS"
 
-  influxdbjail:
-    blueprint: influxdb
-    ip4_addr: 192.168.1.250/24
-    gateway: 192.168.1.1
+influxdbjail:
+  blueprint: influxdb
+  ip4_addr: 192.168.1.213/24
+  gateway: 192.168.1.1
 
-  unifijail:
-    blueprint: unifi
-    ip4_addr: 192.168.1.251/24
-    gateway: 192.168.1.1
-    poller: true
-    link_influxdb: influxdbjail
-    influxdb_password: unifi-poller
-    poller_password: upoller
+unifijail:
+  blueprint: unifi
+  ip4_addr: 192.168.1.214/24
+  gateway: 192.168.1.1
+  poller: true
+  link_influxdb: influxdbjail
+  influxdb_password: unifi-poller
+  poller_password: upoller
 
-  grafanajail:
-    blueprint: grafana
-    ip4_addr: 192.168.1.100/24
-    gateway: 192.168.1.1
-    password: grafana
-    link_influxdb: influxdbjail
-    link_unifi: unifijail
+grafanajail:
+  blueprint: grafana
+  ip4_addr: 192.168.1.215/24
+  gateway: 192.168.1.1
+  password: grafana
+  link_influxdb: influxdbjail
+  link_unifi: unifijail
 
-  forked_daapdjail:
-    blueprint: forked_daapd
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
-    itunes_media: /mnt/itunes
+forked_daapdjail:
+  blueprint: forked_daapd
+  ip4_addr: 192.168.1.216/24
+  gateway: 192.168.1.1
+  itunes_media: /mnt/itunes
 
-  traefikjail:
-    blueprint: traefik
-    ip4_addr: 192.168.1.250/24
-    gateway: 192.168.1.1
-    dashboard: true
-    domain_name: traefik.test.placeholder.net
-    dns_provider: cloudflare
-    cert_staging: true
-    cert_email: fake@email.net
-    cert_wildcard_domain: test.placeholder.net
-    # Please follow the guide here: https://docs.traefik.io/https/acme/
-    # and enter your DNS providers environment variables below (2 spaces indent) of cert_env
-    cert_env:
-      CF_API_EMAIL: fake@email.adress
-      CF_API_KEY: ftyhsfgufsgusfgjhsfghjsgfhj
+traefikjail:
+  blueprint: traefik
+  ip4_addr: 192.168.1.217/24
+  gateway: 192.168.1.1
+  dashboard: true
+  domain_name: traefik.test.placeholder.net
+  dns_provider: cloudflare
+  cert_staging: true
+  cert_email: fake@email.net
+  cert_wildcard_domain: test.placeholder.net
+  # Please follow the guide here: https://docs.traefik.io/https/acme/
+  # and enter your DNS providers environment variables below (2 spaces indent) of cert_env
+  cert_env:
+    CF_API_EMAIL: fake@email.adress
+    CF_API_KEY: ftyhsfgufsgusfgjhsfghjsgfhj
 
-  sabnzbdjail:
-    blueprint: sabnzbd
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
+sabnzbdjail:
+  blueprint: sabnzbd
+  ip4_addr: 192.168.1.218/24
+  gateway: 192.168.1.1
 
-  sabnzbd3:
-    blueprint: sabnzbd3
-    ip4_addr: 192.168.1.99/24
-    gateway: 192.168.1.1
+sabnzbd3:
+  blueprint: sabnzbd3
+  ip4_addr: 192.168.1.219/24
+  gateway: 192.168.1.1
 

--- a/includes/global.json
+++ b/includes/global.json
@@ -1,0 +1,18 @@
+{
+	"jailman": {
+		"variables": {
+			"options": [
+				"ip4_addr",
+				"host_name",
+				"gateway",
+				"link_traefik",
+				"domain_name",
+				"traefik_service_port",
+				"traefik_auth_basic",
+				"traefik_auth_forward"
+			],
+			"required": []
+		}
+	},
+	"revision": "0"
+}

--- a/includes/global.yml
+++ b/includes/global.yml
@@ -1,4 +1,0 @@
-global:
-  jails:
-   vars: ip4_addr host_name gateway link_traefik domain_name traefik_service_port traefik_auth_basic traefik_auth_forward
-   reqvars: 

--- a/includes/init_functions.sh
+++ b/includes/init_functions.sh
@@ -53,11 +53,6 @@ validate_config() {
 }
 
 load_config() {
-	# Parse the Config YAML
-	cfg=$(parse_yaml "${SCRIPT_DIR}/includes/global.yml")
-	validate_config "${SCRIPT_DIR}/includes/global.yml" "$cfg"
-	eval "$cfg"
-
 	cfg=$(parse_yaml "${SCRIPT_DIR}/config.yml")
 	validate_config "${SCRIPT_DIR}/config.yml" "$cfg"
 	eval "$cfg"

--- a/summaries/readme.md
+++ b/summaries/readme.md
@@ -1,0 +1,1 @@
+This folder will contain summeries for your jailman runs.


### PR DESCRIPTION
This PR cleans up and simplifies some portions of the codebase.

- remove jail_ prefix (Fixes #205 )
- incremend IP-adresses in config.yml
- Fix ports, 
- remove unneeded whitespace, 
- remove plugin_extra_conf (not possible anymore)
- removes explicity dhcp setting
- removes override dhcp setting
- adds/moves warning in case dhcp is used
- Removes redundant whitespace-after-variable check
- Adds shortcuts for echo colors
- Move global config to json file (same structure as manifests) (Fixes #204 )
- Add config removal option (Fixes #122 )
- Add logging to /var/log/jailman.log
- Add summary generation (Fixes #14)
- Add automatically creating /root/PLUGIN_INFO for plugins being installed